### PR TITLE
Infohash precheck

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,8 +4,7 @@ from colorama import Fore
 from src.api import RedAPI, OpsAPI
 from src.args import parse_args
 from src.config import Config
-from src.torrent import generate_new_torrent_from_file
-from src.scanner import scan_torrent_directory
+from src.scanner import scan_torrent_directory, scan_torrent_file
 
 from src.webserver import run_webserver
 
@@ -22,11 +21,9 @@ def cli_entrypoint():
     if args.server:
       run_webserver(args.input_directory, args.output_directory, red_api, ops_api, port=os.environ.get("PORT", 9713))
     elif args.input_file:
-      _, torrent_path = generate_new_torrent_from_file(args.input_file, args.output_directory, red_api, ops_api)
-      print(torrent_path)
+      print(scan_torrent_file(args.input_file, args.output_directory, red_api, ops_api))
     elif args.input_directory:
-      report = scan_torrent_directory(args.input_directory, args.output_directory, red_api, ops_api)
-      print(report)
+      print(scan_torrent_directory(args.input_directory, args.output_directory, red_api, ops_api))
   except Exception as e:
     print(f"{Fore.RED}{str(e)}{Fore.RESET}")
     exit(1)

--- a/src/parser.py
+++ b/src/parser.py
@@ -41,14 +41,15 @@ def get_origin_tracker(torrent_data: dict) -> RedTracker | OpsTracker | None:
   return None
 
 
+def calculate_infohash(torrent_data: dict) -> str:
+  return sha1(bencoder.encode(torrent_data[b"info"])).hexdigest().upper()
+
+
 def recalculate_hash_for_new_source(torrent_data: dict, new_source: (bytes | str)) -> str:
   torrent_data = copy.deepcopy(torrent_data)
-  new_source = new_source.encode() if isinstance(new_source, str) else new_source
-
   torrent_data[b"info"][b"source"] = new_source
-  hash = sha1(bencoder.encode(torrent_data[b"info"])).hexdigest().upper()
 
-  return hash
+  return calculate_infohash(torrent_data)
 
 
 def get_torrent_data(filename: str) -> dict:

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -4,6 +4,7 @@ from .api import RedAPI, OpsAPI
 from .filesystem import mkdir_p, list_files_of_extension, assert_path_exists
 from .progress import Progress
 from .torrent import generate_new_torrent_from_file
+from .parser import get_torrent_data, calculate_infohash
 from .errors import TorrentDecodingError, UnknownTrackerError, TorrentNotFoundError, TorrentAlreadyExistsError
 
 
@@ -29,10 +30,15 @@ def scan_torrent_directory(
 
   input_directory = assert_path_exists(input_directory)
   output_directory = mkdir_p(output_directory)
-  local_torrents = list_files_of_extension(input_directory, ".torrent")
-  p = Progress(len(local_torrents))
 
-  for i, torrent_path in enumerate(local_torrents, 1):
+  input_torrents = list_files_of_extension(input_directory, ".torrent")
+  output_torrents = list_files_of_extension(output_directory, ".torrent")
+  input_infohashes = __collect_infohashes_from_files(input_torrents)
+  output_infohashes = __collect_infohashes_from_files(output_torrents)
+
+  p = Progress(len(input_torrents))
+
+  for i, torrent_path in enumerate(input_torrents, 1):
     basename = os.path.basename(torrent_path)
     print(f"({i}/{p.total}) {basename}")
 
@@ -42,6 +48,8 @@ def scan_torrent_directory(
         output_directory,
         red_api,
         ops_api,
+        input_infohashes,
+        output_infohashes,
       )
 
       p.generated.print(
@@ -53,8 +61,8 @@ def scan_torrent_directory(
     except UnknownTrackerError as e:
       p.skipped.print(str(e))
       continue
-    except TorrentAlreadyExistsError:
-      p.already_exists.print("Found, but the output .torrent already exists.")
+    except TorrentAlreadyExistsError as e:
+      p.already_exists.print(str(e))
       continue
     except TorrentNotFoundError as e:
       p.not_found.print(str(e))
@@ -64,3 +72,16 @@ def scan_torrent_directory(
       continue
 
   return p.report()
+
+
+def __collect_infohashes_from_files(files: list[str]) -> dict:
+  infohash_dict = {}
+
+  for filename in files:
+    torrent_data = get_torrent_data(filename)
+
+    if torrent_data:
+      infohash = calculate_infohash(torrent_data)
+      infohash_dict[infohash] = torrent_data[b"info"][b"name"].decode()
+
+  return infohash_dict

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -8,6 +8,43 @@ from .parser import get_torrent_data, calculate_infohash
 from .errors import TorrentDecodingError, UnknownTrackerError, TorrentNotFoundError, TorrentAlreadyExistsError
 
 
+def scan_torrent_file(
+  torrent_path: str,
+  output_directory: str,
+  red_api: RedAPI,
+  ops_api: OpsAPI,
+) -> str:
+  """
+  Scans a single .torrent file and generates a new one using the tracker API.
+
+  Args:
+    `torrent_path` (`str`): The path to the .torrent file.
+    `output_directory` (`str`): The directory to save the new .torrent files.
+    `red_api` (`RedAPI`): The pre-configured RED tracker API.
+    `ops_api` (`OpsAPI`): The pre-configured OPS tracker API.
+  Returns:
+    str: The path to the new .torrent file.
+  Raises:
+    See `generate_new_torrent_from_file`.
+  """
+  torrent_path = assert_path_exists(torrent_path)
+  output_directory = mkdir_p(output_directory)
+
+  output_torrents = list_files_of_extension(output_directory, ".torrent")
+  output_infohashes = __collect_infohashes_from_files(output_torrents)
+
+  _new_tracker, new_torrent_filepath = generate_new_torrent_from_file(
+    torrent_path,
+    output_directory,
+    red_api,
+    ops_api,
+    input_infohashes={},
+    output_infohashes=output_infohashes,
+  )
+
+  return new_torrent_filepath
+
+
 def scan_torrent_directory(
   input_directory: str,
   output_directory: str,

--- a/src/webserver.py
+++ b/src/webserver.py
@@ -2,7 +2,7 @@ import os
 from flask import Flask, request
 
 from src.parser import is_valid_infohash
-from src.torrent import generate_new_torrent_from_file
+from src.scanner import scan_torrent_file
 from src.errors import TorrentAlreadyExistsError, TorrentNotFoundError
 
 app = Flask(__name__)
@@ -24,7 +24,7 @@ def webhook():
     return http_error(f"No torrent found at {filepath}", 404)
 
   try:
-    _, new_filepath = generate_new_torrent_from_file(
+    new_filepath = scan_torrent_file(
       filepath,
       config["output_dir"],
       config["red_api"],

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -11,10 +11,11 @@ from src.parser import (
   get_origin_tracker,
   recalculate_hash_for_new_source,
   save_torrent_data,
+  calculate_infohash,
 )
 
 
-class TestParserIsValidInfohash(SetupTeardown):
+class TestIsValidInfohash(SetupTeardown):
   def test_returns_true_for_valid_infohash(self):
     assert is_valid_infohash("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")
 
@@ -25,7 +26,7 @@ class TestParserIsValidInfohash(SetupTeardown):
     assert not is_valid_infohash(123)
 
 
-class TestParserGetSource(SetupTeardown):
+class TestGetSource(SetupTeardown):
   def test_returns_source_if_present(self):
     assert get_source({b"info": {b"source": b"FOO"}}) == b"FOO"
 
@@ -33,7 +34,7 @@ class TestParserGetSource(SetupTeardown):
     assert get_source({}) is None
 
 
-class TestParserGetAnnounceUrl(SetupTeardown):
+class TestGetAnnounceUrl(SetupTeardown):
   def test_returns_url_if_present(self):
     assert get_announce_url({b"announce": b"https://foo.bar"}) == b"https://foo.bar"
 
@@ -41,7 +42,7 @@ class TestParserGetAnnounceUrl(SetupTeardown):
     assert get_announce_url({}) is None
 
 
-class TestParserGetOriginTracker(SetupTeardown):
+class TestGetOriginTracker(SetupTeardown):
   def test_returns_red_based_on_source(self):
     assert get_origin_tracker({b"info": {b"source": b"RED"}}) == RedTracker
     assert get_origin_tracker({b"info": {b"source": b"PTH"}}) == RedTracker
@@ -61,7 +62,15 @@ class TestParserGetOriginTracker(SetupTeardown):
     assert get_origin_tracker({b"announce": b"https://foo/123abc"}) is None
 
 
-class TestParserReplaceSourceAndReturnHash(SetupTeardown):
+class TestCalculateInfohash(SetupTeardown):
+  def test_returns_infohash(self):
+    torrent_data = {b"info": {b"source": b"RED"}}
+    result = calculate_infohash(torrent_data)
+
+    assert result == "FD2F1D966DF7E2E35B0CF56BC8510C6BB4D44467"
+
+
+class TestRecalculateHashForNewSource(SetupTeardown):
   def test_replaces_source_and_returns_hash(self):
     torrent_data = {b"info": {b"source": b"RED"}}
     new_source = b"OPS"
@@ -79,7 +88,7 @@ class TestParserReplaceSourceAndReturnHash(SetupTeardown):
     assert torrent_data == {b"info": {b"source": b"RED"}}
 
 
-class TestParserGetTorrentData(SetupTeardown):
+class TestGetTorrentData(SetupTeardown):
   def test_returns_torrent_data(self):
     result = get_torrent_data(get_torrent_path("no_source"))
 
@@ -92,7 +101,7 @@ class TestParserGetTorrentData(SetupTeardown):
     assert result is None
 
 
-class TestParserSaveTorrentData(SetupTeardown):
+class TestSaveTorrentData(SetupTeardown):
   def test_saves_torrent_data(self):
     torrent_data = {b"info": {b"source": b"RED"}}
     filename = "/tmp/test_save_torrent_data.torrent"


### PR DESCRIPTION
Pre-checks input and output directories for infohashes matching the new torrent. Saves a ton of time and API requests.

Based on https://github.com/soranosita/crops/pull/5