### PR TITLE
Adds API checks on app boot

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,8 +9,7 @@ from src.scanner import scan_torrent_directory, scan_torrent_file
 from src.webserver import run_webserver
 
 
-def cli_entrypoint():
-  args = parse_args()
+def cli_entrypoint(args):
   config = Config().load(args.config_file)
 
   # TODO: confirm that both trackers can be accessed before starting the scan
@@ -30,8 +29,10 @@ def cli_entrypoint():
 
 
 if __name__ == "__main__":
+  args = parse_args()
+
   try:
-    cli_entrypoint()
+    cli_entrypoint(args)
   except KeyboardInterrupt:
     print(f"{Fore.RED}Exiting...{Fore.RESET}")
     exit(1)

--- a/main.py
+++ b/main.py
@@ -11,10 +11,7 @@ from src.webserver import run_webserver
 
 def cli_entrypoint(args):
   config = Config().load(args.config_file)
-
-  # TODO: confirm that both trackers can be accessed before starting the scan
-  red_api = RedAPI(config.red_key)
-  ops_api = OpsAPI(config.ops_key)
+  red_api, ops_api = __verify_api_keys(config)
 
   try:
     if args.server:
@@ -26,6 +23,18 @@ def cli_entrypoint(args):
   except Exception as e:
     print(f"{Fore.RED}{str(e)}{Fore.RESET}")
     exit(1)
+
+
+def __verify_api_keys(config):
+  red_api = RedAPI(config.red_key)
+  ops_api = OpsAPI(config.ops_key)
+
+  # This will perform a lookup with the API and raise if there was a failure.
+  # Also caches the announce URL for future use which is a nice bonus
+  red_api.announce_url
+  ops_api.announce_url
+
+  return red_api, ops_api
 
 
 if __name__ == "__main__":

--- a/src/api.py
+++ b/src/api.py
@@ -102,6 +102,8 @@ class OpsAPI(GazelleAPI):
       rate_limit=delay_in_seconds,
     )
 
+    self.sitename = "OPS"
+
 
 class RedAPI(GazelleAPI):
   def __init__(self, api_key, delay_in_seconds=2):
@@ -111,3 +113,5 @@ class RedAPI(GazelleAPI):
       auth_header={"Authorization": api_key},
       rate_limit=delay_in_seconds,
     )
+
+    self.sitename = "RED"


### PR DESCRIPTION
Checks that both the RED and OPS APIs can be accessed on app boot. Has the side-benefit of caching the announce URL