### PR TITLE
Add alternate source names for OPS and RED

### DIFF
--- a/src/torrent.py
+++ b/src/torrent.py
@@ -46,6 +46,7 @@ def generate_new_torrent_from_file(
   new_torrent_data = copy.deepcopy(source_torrent_data)
   new_tracker = source_tracker.reciprocal_tracker()
   new_tracker_api = __get_reciprocal_tracker_api(new_tracker, red_api, ops_api)
+  stored_api_response = None
 
   for new_source in new_tracker.source_flags_for_creation():
     new_hash = recalculate_hash_for_new_source(source_torrent_data, new_source)
@@ -55,27 +56,28 @@ def generate_new_torrent_from_file(
     if new_hash in output_infohashes:
       raise TorrentAlreadyExistsError(f"Torrent already exists in output directory as {output_infohashes[new_hash]}")
 
-    api_response = new_tracker_api.find_torrent(new_hash)
+    stored_api_response = new_tracker_api.find_torrent(new_hash)
 
-    if api_response["status"] == "success":
+    if stored_api_response["status"] == "success":
       new_torrent_filepath = generate_torrent_output_filepath(
-        api_response,
+        stored_api_response,
         new_source.decode("utf-8"),
         output_directory,
       )
 
       if new_torrent_filepath:
-        torrent_id = __get_torrent_id(api_response)
+        torrent_id = __get_torrent_id(stored_api_response)
 
         new_torrent_data[b"info"][b"source"] = new_source  # This is already bytes rather than str
         new_torrent_data[b"announce"] = new_tracker_api.announce_url.encode()
         new_torrent_data[b"comment"] = __generate_torrent_url(new_tracker_api.site_url, torrent_id).encode()
 
         return (new_tracker, save_bencoded_data(new_torrent_filepath, new_torrent_data))
-    elif api_response["error"] in ("bad hash parameter", "bad parameters"):
-      raise TorrentNotFoundError(f"Torrent could not be found on {new_tracker.site_shortname()}")
-    else:
-      raise Exception(f"An unknown error occurred in the API response from {new_tracker.site_shortname()}")
+
+  if stored_api_response["error"] in ("bad hash parameter", "bad parameters"):
+    raise TorrentNotFoundError(f"Torrent could not be found on {new_tracker.site_shortname()}")
+  else:
+    raise Exception(f"An unknown error occurred in the API response from {new_tracker.site_shortname()}")
 
 
 def generate_torrent_output_filepath(api_response: dict, new_source: str, output_directory: str) -> str:

--- a/src/trackers.py
+++ b/src/trackers.py
@@ -23,7 +23,7 @@ class Tracker:
 class OpsTracker(Tracker):
   @staticmethod
   def source_flags_for_search():
-    return [b"OPS"]
+    return [b"OPS", b"APL"]
 
   @staticmethod
   def source_flags_for_creation():

--- a/src/trackers.py
+++ b/src/trackers.py
@@ -27,7 +27,7 @@ class OpsTracker(Tracker):
 
   @staticmethod
   def source_flags_for_creation():
-    return [b"OPS"]
+    return [b"OPS", b"APL", b""]
 
   @staticmethod
   def announce_url():
@@ -49,7 +49,7 @@ class RedTracker(Tracker):
 
   @staticmethod
   def source_flags_for_creation():
-    return [b"RED"]
+    return [b"RED", b"PTH", b""]
 
   @staticmethod
   def announce_url():

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -6,11 +6,11 @@ from src.trackers import RedTracker, OpsTracker
 class TestTrackerMethods(SetupTeardown):
   def test_source_flags_for_search(self):
     assert RedTracker.source_flags_for_search() == [b"RED", b"PTH"]
-    assert OpsTracker.source_flags_for_search() == [b"OPS"]
+    assert OpsTracker.source_flags_for_search() == [b"OPS", b"APL"]
 
   def test_source_flags_for_creation(self):
-    assert RedTracker.source_flags_for_creation() == [b"RED"]
-    assert OpsTracker.source_flags_for_creation() == [b"OPS"]
+    assert RedTracker.source_flags_for_creation() == [b"RED", b"PTH", b""]
+    assert OpsTracker.source_flags_for_creation() == [b"OPS", b"APL", b""]
 
   def test_announce_url(self):
     assert RedTracker.announce_url() == b"flacsfor.me"


### PR DESCRIPTION
OPS sources can be OPS, APL, or blank. RED's can be RED, PTH, or blank.

I've updated the script to 1) look for APL and PTH when determining a torrent's origin, and 2) search for torrents belonging to APL, PTH, and <blank> when querying the API to determine if the reciprocal tracker actually has the torrent in question