### PR TITLE
Allow injection of previously-generated torrent files

### DIFF
--- a/src/clients/qbittorrent.py
+++ b/src/clients/qbittorrent.py
@@ -5,7 +5,7 @@ from requests.structures import CaseInsensitiveDict
 
 from ..filesystem import sane_join
 from ..parser import get_bencoded_data, calculate_infohash
-from ..errors import TorrentClientError, TorrentClientAuthenticationError
+from ..errors import TorrentClientError, TorrentClientAuthenticationError, TorrentExistsInClientError
 from .torrent_client import TorrentClient
 
 
@@ -46,7 +46,7 @@ class Qbittorrent(TorrentClient):
     new_torrent_already_exists = self.__does_torrent_exist_in_client(new_torrent_infohash)
 
     if new_torrent_already_exists:
-      raise TorrentClientError(f"New torrent already exists in client ({new_torrent_infohash})")
+      raise TorrentExistsInClientError(f"New torrent already exists in client ({new_torrent_infohash})")
 
     injection_filename = f"{Path(new_torrent_filepath).stem}.fertilizer.torrent"
     torrents = {"torrents": (injection_filename, open(new_torrent_filepath, "rb"), "application/x-bittorrent")}

--- a/src/errors.py
+++ b/src/errors.py
@@ -50,6 +50,10 @@ class TorrentClientError(Exception):
   pass
 
 
+class TorrentExistsInClientError(Exception):
+  pass
+
+
 class TorrentClientAuthenticationError(Exception):
   pass
 

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -5,7 +5,13 @@ from .filesystem import mkdir_p, list_files_of_extension, assert_path_exists
 from .progress import Progress
 from .torrent import generate_new_torrent_from_file
 from .parser import get_bencoded_data, calculate_infohash
-from .errors import TorrentDecodingError, UnknownTrackerError, TorrentNotFoundError, TorrentAlreadyExistsError
+from .errors import (
+  TorrentDecodingError,
+  UnknownTrackerError,
+  TorrentNotFoundError,
+  TorrentAlreadyExistsError,
+  TorrentExistsInClientError,
+)
 from .injection import Injection
 
 
@@ -102,7 +108,6 @@ def scan_torrent_directory(
       )
 
       if injector:
-        # TODO: ensure the error from a torrent already existing is caught and handled
         injector.inject_torrent(
           source_torrent_path,
           new_torrent_filepath,
@@ -125,6 +130,9 @@ def scan_torrent_directory(
       p.skipped.print(str(e))
       continue
     except TorrentAlreadyExistsError as e:
+      p.already_exists.print(str(e))
+      continue
+    except TorrentExistsInClientError as e:
       p.already_exists.print(str(e))
       continue
     except TorrentNotFoundError as e:

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -36,7 +36,7 @@ def scan_torrent_file(
   output_torrents = list_files_of_extension(output_directory, ".torrent")
   output_infohashes = __collect_infohashes_from_files(output_torrents)
 
-  new_tracker, new_torrent_filepath = generate_new_torrent_from_file(
+  new_tracker, new_torrent_filepath, _ = generate_new_torrent_from_file(
     source_torrent_path,
     output_directory,
     red_api,
@@ -92,7 +92,7 @@ def scan_torrent_directory(
     print(f"({i}/{p.total}) {basename}")
 
     try:
-      new_tracker, new_torrent_filepath = generate_new_torrent_from_file(
+      new_tracker, new_torrent_filepath, was_previously_generated = generate_new_torrent_from_file(
         source_torrent_path,
         output_directory,
         red_api,
@@ -102,15 +102,22 @@ def scan_torrent_directory(
       )
 
       if injector:
+        # TODO: ensure the error from a torrent already existing is caught and handled
         injector.inject_torrent(
           source_torrent_path,
           new_torrent_filepath,
           new_tracker.site_shortname(),
         )
 
-      p.generated.print(
-        f"Found with source '{new_tracker.site_shortname()}' and generated as '{new_torrent_filepath}'."
-      )
+      if was_previously_generated:
+        if injector:
+          p.already_exists.print("Torrent was previously generated but was injected into your torrent client.")
+        else:
+          p.already_exists.print("Torrent was previously generated.")
+      else:
+        p.generated.print(
+          f"Found with source '{new_tracker.site_shortname()}' and generated as '{new_torrent_filepath}'."
+        )
     except TorrentDecodingError as e:
       p.error.print(str(e))
       continue
@@ -133,13 +140,13 @@ def scan_torrent_directory(
 def __collect_infohashes_from_files(files: list[str]) -> dict:
   infohash_dict = {}
 
-  for filename in files:
+  for filepath in files:
     try:
-      torrent_data = get_bencoded_data(filename)
+      torrent_data = get_bencoded_data(filepath)
 
       if torrent_data:
         infohash = calculate_infohash(torrent_data)
-        infohash_dict[infohash] = torrent_data[b"info"][b"name"].decode("utf-8")
+        infohash_dict[infohash] = filepath
     except UnicodeDecodeError:
       continue
 

--- a/tests/clients/test_qbittorrent.py
+++ b/tests/clients/test_qbittorrent.py
@@ -4,7 +4,7 @@ import requests_mock
 
 from tests.helpers import SetupTeardown, get_torrent_path
 
-from src.errors import TorrentClientError, TorrentClientAuthenticationError
+from src.errors import TorrentClientError, TorrentClientAuthenticationError, TorrentExistsInClientError
 from src.clients.qbittorrent import Qbittorrent
 
 
@@ -136,7 +136,7 @@ class TestInjectTorrent(SetupTeardown):
     with requests_mock.Mocker() as m:
       m.post(re.compile("torrents/info"), [{"json": [torrent_info_response]}, {"json": [torrent_info_response]}])
 
-      with pytest.raises(TorrentClientError) as excinfo:
+      with pytest.raises(TorrentExistsInClientError) as excinfo:
         qbit_client.inject_torrent("foo", torrent_path)
 
       assert "New torrent already exists in client" in str(excinfo.value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import requests_mock
 
 from src.config import Config
 from src.api import RedAPI, OpsAPI
@@ -26,3 +27,10 @@ def ops_api():
   instance = OpsAPI("opssecret", delay_in_seconds=0)
   instance._max_retries = 1
   return instance
+
+
+# This _should_ prevent all tests from making real requests to the internet.
+@pytest.fixture(autouse=True)
+def stub_or_disable_requests():
+  with requests_mock.Mocker():
+    yield

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -43,15 +43,6 @@ class TestScanTorrentFile(SetupTeardown):
       assert os.path.isfile(filepath)
       assert filepath == "/tmp/output/OPS/foo [OPS].torrent"
 
-  def test_considers_matching_output_torrents_as_already_existing(self, capsys, red_api, ops_api):
-    copy_and_mkdir(get_torrent_path("red_source"), "/tmp/input/red_source.torrent")
-    copy_and_mkdir(get_torrent_path("ops_source"), "/tmp/output/ops_source.torrent")
-
-    with pytest.raises(TorrentAlreadyExistsError) as excinfo:
-      scan_torrent_file("/tmp/input/red_source.torrent", "/tmp/output", red_api, ops_api, None)
-
-    assert str(excinfo.value) == "Torrent already exists in output directory as Big Buck Bunny"
-
   def test_calls_injector_if_provided(self, red_api, ops_api):
     injector_mock = MagicMock()
     injector_mock.inject_torrent = MagicMock()
@@ -65,6 +56,23 @@ class TestScanTorrentFile(SetupTeardown):
 
     injector_mock.inject_torrent.assert_called_once_with(
       "/tmp/input/red_source.torrent", "/tmp/output/OPS/foo [OPS].torrent", "OPS"
+    )
+
+  def test_calls_injector_if_torrent_is_duplicate(self, red_api, ops_api):
+    injector_mock = MagicMock()
+    injector_mock.inject_torrent = MagicMock()
+
+    copy_and_mkdir(get_torrent_path("red_source"), "/tmp/input/red_source.torrent")
+    copy_and_mkdir(get_torrent_path("ops_source"), "/tmp/output/ops_source.torrent")
+
+    with requests_mock.Mocker() as m:
+      m.get(re.compile("action=torrent"), json=self.TORRENT_SUCCESS_RESPONSE)
+      m.get(re.compile("action=index"), json=self.ANNOUNCE_SUCCESS_RESPONSE)
+
+      scan_torrent_file("/tmp/input/red_source.torrent", "/tmp/output", red_api, ops_api, injector_mock)
+
+    injector_mock.inject_torrent.assert_called_once_with(
+      "/tmp/input/red_source.torrent", "/tmp/output/ops_source.torrent", "OPS"
     )
 
   def test_doesnt_blow_up_if_other_torrent_name_has_bad_encoding(self, red_api, ops_api):
@@ -137,10 +145,7 @@ class TestScanTorrentDirectory(SetupTeardown):
       print(scan_torrent_directory("/tmp/input", "/tmp/output", red_api, ops_api, None))
       captured = capsys.readouterr()
 
-      assert (
-        f"{Fore.LIGHTYELLOW_EX}Torrent file already exists at /tmp/output/OPS/foo [OPS].torrent{Fore.RESET}"
-        in captured.out
-      )
+      assert f"{Fore.LIGHTYELLOW_EX}Torrent was previously generated.{Fore.RESET}" in captured.out
       assert f"{Fore.LIGHTYELLOW_EX}Already exists{Fore.RESET}: 1" in captured.out
 
   def test_considers_matching_input_torrents_as_already_existing(self, capsys, red_api, ops_api):
@@ -151,8 +156,10 @@ class TestScanTorrentDirectory(SetupTeardown):
     captured = capsys.readouterr()
 
     assert (
-      f"{Fore.LIGHTYELLOW_EX}Torrent already exists in input directory as Big Buck Bunny{Fore.RESET}" in captured.out
+      f"{Fore.LIGHTYELLOW_EX}Torrent already exists in input directory at /tmp/input/red_source.torrent{Fore.RESET}"
+      in captured.out
     )
+
     assert f"{Fore.LIGHTYELLOW_EX}Already exists{Fore.RESET}: 2" in captured.out
 
   def test_considers_matching_output_torrents_as_already_existing(self, capsys, red_api, ops_api):
@@ -162,10 +169,27 @@ class TestScanTorrentDirectory(SetupTeardown):
     print(scan_torrent_directory("/tmp/input", "/tmp/output", red_api, ops_api, None))
     captured = capsys.readouterr()
 
+    assert f"{Fore.LIGHTYELLOW_EX}Torrent was previously generated.{Fore.RESET}" in captured.out
+    assert f"{Fore.LIGHTYELLOW_EX}Already exists{Fore.RESET}: 1" in captured.out
+
+  def test_returns_calls_injector_on_duplicate(self, capsys, red_api, ops_api):
+    injector_mock = MagicMock()
+    injector_mock.inject_torrent = MagicMock()
+
+    copy_and_mkdir(get_torrent_path("red_source"), "/tmp/input/red_source.torrent")
+    copy_and_mkdir(get_torrent_path("ops_source"), "/tmp/output/ops_source.torrent")
+
+    print(scan_torrent_directory("/tmp/input", "/tmp/output", red_api, ops_api, injector_mock))
+    captured = capsys.readouterr()
+
     assert (
-      f"{Fore.LIGHTYELLOW_EX}Torrent already exists in output directory as Big Buck Bunny{Fore.RESET}" in captured.out
+      f"{Fore.LIGHTYELLOW_EX}Torrent was previously generated but was injected into your torrent client.{Fore.RESET}"
+      in captured.out
     )
     assert f"{Fore.LIGHTYELLOW_EX}Already exists{Fore.RESET}: 1" in captured.out
+    injector_mock.inject_torrent.assert_called_once_with(
+      "/tmp/input/red_source.torrent", "/tmp/output/ops_source.torrent", "OPS"
+    )
 
   def test_lists_not_found_torrents(self, capsys, red_api, ops_api):
     copy_and_mkdir(get_torrent_path("red_source"), "/tmp/input/red_source.torrent")

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -64,7 +64,9 @@ class TestGenerateNewTorrentFromFile(SetupTeardown):
       m.get(re.compile("action=index"), json=self.ANNOUNCE_SUCCESS_RESPONSE)
 
       torrent_path = get_torrent_path("ops_source")
-      new_tracker, filepath, previously_generated = generate_new_torrent_from_file(torrent_path, "/tmp", red_api, ops_api)
+      new_tracker, filepath, previously_generated = generate_new_torrent_from_file(
+        torrent_path, "/tmp", red_api, ops_api
+      )
       get_bencoded_data(filepath)
 
       assert os.path.isfile(filepath)
@@ -142,7 +144,9 @@ class TestGenerateNewTorrentFromFile(SetupTeardown):
     output_hashes = {"2AEE440CDC7429B3E4A7E4D20E3839DBB48D72C2": "bar"}
 
     torrent_path = get_torrent_path("red_source")
-    _, _, previously_generated = generate_new_torrent_from_file(torrent_path, "/tmp", red_api, ops_api, {}, output_hashes)
+    _, _, previously_generated = generate_new_torrent_from_file(
+      torrent_path, "/tmp", red_api, ops_api, {}, output_hashes
+    )
 
     assert previously_generated
 

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -74,7 +74,7 @@ class TestWebserverWebhook(SetupTeardown):
       assert response.json == {"status": "success", "message": "/tmp/output/OPS/foo [OPS].torrent"}
       assert os.path.exists("/tmp/output/OPS/foo [OPS].torrent")
 
-  def test_raises_error_if_torrent_already_exists(self, client, infohash):
+  def test_returns_okay_if_torrent_already_found(self, client, infohash):
     copy_and_mkdir(get_torrent_path("red_source"), f"/tmp/input/{infohash}.torrent")
     copy_and_mkdir(get_torrent_path("red_source"), "/tmp/output/OPS/foo [OPS].torrent")
 
@@ -83,11 +83,8 @@ class TestWebserverWebhook(SetupTeardown):
       m.get(re.compile("action=index"), json=self.ANNOUNCE_SUCCESS_RESPONSE)
 
       response = client.post("/api/webhook", data={"infohash": infohash})
-      assert response.status_code == 409
-      assert response.json == {
-        "status": "error",
-        "message": "Torrent file already exists at /tmp/output/OPS/foo [OPS].torrent",
-      }
+      assert response.status_code == 201
+      assert response.json == {"status": "success", "message": "/tmp/output/OPS/foo [OPS].torrent"}
 
   def test_raises_error_if_torrent_not_found(self, client, infohash):
     copy_and_mkdir(get_torrent_path("red_source"), f"/tmp/input/{infohash}.torrent")


### PR DESCRIPTION
Previously, encountering a torrent that was previously generated was an error. Now it's treated as idempotent and no error will be raised if the user attempts to re-generate an existing torrent. No work will be done, but it won't error out and it returns the same value as if it were successful (except when running a directory scan)

This lets the user inject torrents that were previously created. The use-case is that someone got started with fertilizer and now wants to move the torrents they generated during testing into their torrent client.

The pre-checks for existing torrents in the _input_ directory still hold which should prevent checks from being made if the torrent already exists in the client. If that fails, the logic for inserting existing torrents has changed to give more information to the user