### PR TITLE
Add verbose output option

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import sys
+import traceback
 from colorama import Fore
 
 from src.api import RedAPI, OpsAPI
@@ -29,6 +30,9 @@ def cli_entrypoint(args):
     elif args.input_directory:
       print(scan_torrent_directory(args.input_directory, args.output_directory, red_api, ops_api, injector))
   except Exception as e:
+    if args.verbose:
+      print(traceback.format_exc())
+
     print(f"{Fore.RED}{str(e)}{Fore.RESET}")
     exit(1)
 

--- a/src/args.py
+++ b/src/args.py
@@ -55,6 +55,14 @@ def parse_args(args=None):
     default=False,
   )
 
+  options.add_argument(
+    "-v",
+    "--verbose",
+    action="store_true",
+    help="enables verbose output",
+    default=False,
+  )
+
   config.add_argument(
     "-c",
     "--config-file",


### PR DESCRIPTION
Adds a `-v`/`--verbose` flag that prints the full stack trace if it encounters an error