### PR TITLE
feat: Add config option for server host

### DIFF
--- a/src/fertilizer/config.py
+++ b/src/fertilizer/config.py
@@ -20,6 +20,7 @@ class Config:
       for key, value in {
         "red_key": env_vars.get("RED_KEY"),
         "ops_key": env_vars.get("OPS_KEY"),
+        "host": env_vars.get("HOST"),
         "port": env_vars.get("PORT"),
         "inject_torrents": True if env_vars.get("INJECT_TORRENTS", "").lower().strip() == "true" else False,
         "deluge_rpc_url": env_vars.get("DELUGE_RPC_URL"),
@@ -42,6 +43,10 @@ class Config:
   @property
   def ops_key(self) -> str:
     return self._config["ops_key"]
+
+  @property
+  def server_host(self) -> str:
+    return self._config.get("host", "0.0.0.0")
 
   @property
   def server_port(self) -> str:

--- a/src/fertilizer/config_validator.py
+++ b/src/fertilizer/config_validator.py
@@ -120,9 +120,11 @@ class ConfigValidator:
 
   @staticmethod
   def __is_valid_host(host):
-    if ip_address(host):
-      return host
-    raise ValueError(f'Invalid "host" ({host}): Not a valid IP address')
+    try:
+      if ip_address(host):
+        return host
+    except:
+      raise ValueError(f'Invalid "host" ({host}): Not a valid IPv4 or IPv6 address')
 
   @staticmethod
   def __is_valid_port(port):

--- a/src/fertilizer/config_validator.py
+++ b/src/fertilizer/config_validator.py
@@ -1,5 +1,6 @@
 import re
 from urllib.parse import urlparse
+from ipaddress import ip_address
 
 from .api import RedAPI, OpsAPI
 from .filesystem import assert_path_exists
@@ -14,6 +15,7 @@ class ConfigValidator:
     self.validation_schema = {
       "red_key": self.__is_valid_red_key,
       "ops_key": self.__is_valid_ops_key,
+      "host": self.__is_valid_host,
       "port": self.__is_valid_port,
       "deluge_rpc_url": self.__is_valid_deluge_url,
       "transmission_rpc_url": self.__is_valid_transmission_rpc_url,
@@ -115,6 +117,12 @@ class ConfigValidator:
     if coerced in ["true", "false"]:
       return coerced == "true"
     raise ValueError('value is not boolean ("true" or "false")')
+
+  @staticmethod
+  def __is_valid_host(host):
+    if ip_address(host):
+      return host
+    raise ValueError(f'Invalid "host" ({host}): Not a valid IP address')
 
   @staticmethod
   def __is_valid_port(port):

--- a/src/fertilizer/main.py
+++ b/src/fertilizer/main.py
@@ -30,7 +30,7 @@ def cli_entrypoint(args):
     )
 
     if args.server:
-      run_webserver(args.input_directory, args.output_directory, red_api, ops_api, injector, port=config.server_port)
+      run_webserver(args.input_directory, args.output_directory, red_api, ops_api, injector, host=config.server_host, port=config.server_port)
     elif args.input_file:
       print(scan_torrent_file(args.input_file, args.output_directory, red_api, ops_api, injector))
     elif args.input_directory:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,7 @@ class TestBuildFromSources(SetupTeardown):
       {
         "RED_KEY": "red_key",
         "OPS_KEY": "ops_key",
+        "HOST": "192.1.1.1",
         "PORT": "1234",
         "DELUGE_RPC_URL": "http://deluge:8112",
         "QBITTORRENT_URL": "http://qbittorrent:8080",
@@ -37,6 +38,7 @@ class TestBuildFromSources(SetupTeardown):
 
     assert config_dict["red_key"] == "red_key"
     assert config_dict["ops_key"] == "ops_key"
+    assert config_dict["host"] == "192.1.1.1"
     assert config_dict["port"] == "1234"
     assert config_dict["deluge_rpc_url"] == "http://deluge:8112"
     assert config_dict["qbittorrent_url"] == "http://qbittorrent:8080"

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -105,7 +105,7 @@ class TestValidate(SetupTeardown):
     with pytest.raises(ValueError) as excinfo:
       validator.validate()
 
-    assert '- "host": Invalid "host" (not_a_number): Not a valid IP address' in str(excinfo.value)
+    assert '- "host": Invalid "host" (not_an_ip): Not a valid IPv4 or IPv6 address' in str(excinfo.value)
 
   def test_raises_if_port_isnt_valid(self, valid_config):
     valid_config["port"] = "not_a_number"

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -21,6 +21,7 @@ def valid_config(red_key, ops_key):
   return {
     "red_key": red_key,
     "ops_key": ops_key,
+    "host": "192.1.1.1",
     "port": "1234",
     "deluge_rpc_url": "http://:pass@deluge:8112",
     "inject_torrents": "true",
@@ -47,6 +48,7 @@ class TestValidate(SetupTeardown):
     assert validated_config == {
       "red_key": red_key,
       "ops_key": ops_key,
+      "host": "192.1.1.1",
       "port": 1234,
       "deluge_rpc_url": "http://:pass@deluge:8112",
       "inject_torrents": True,
@@ -94,6 +96,16 @@ class TestValidate(SetupTeardown):
 
     assert '- "red_key": does not appear to match known API key patterns: "a"' in str(excinfo.value)
     assert '- "ops_key": does not appear to match known API key patterns: "b"' in str(excinfo.value)
+
+  def test_raises_if_host_isnt_valid(self, valid_config):
+    valid_config["host"] = "not_an_ip"
+
+    validator = ConfigValidator(valid_config)
+
+    with pytest.raises(ValueError) as excinfo:
+      validator.validate()
+
+    assert '- "host": Invalid "host" (not_a_number): Not a valid IP address' in str(excinfo.value)
 
   def test_raises_if_port_isnt_valid(self, valid_config):
     valid_config["port"] = "not_a_number"


### PR DESCRIPTION
Adding a new config option to specify the host for the web server when running in server mode. 

This is useful in my case because by default fertilizer listens on 0.0.0.0 which binds it to the public IP of the server I'm running it on but I don't want it to be public.