### PR TITLE
Update docker (buster to bookworm) and workflows (node 20 to 24)

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Build Artifacts
         run: zip -r fertilizer.zip src pyproject.toml
       - name: Release

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -35,11 +35,11 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -52,20 +52,20 @@ jobs:
             latest=auto
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -29,5 +29,4 @@ jobs:
         run: ruff check
       - name: Check formatting with Ruff
         run: ruff format --check
-      - name: Test with pytest
-        run: pytest
+

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -16,9 +16,9 @@ jobs:
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install pypa/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 
 COPY docker_start ./
 
-RUN apt-get update \
-  && echo "----- Installing python requirements" \
+RUN echo "----- Installing build dependencies" \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc
+    
+# Install build dependencies
+RUN echo "----- Installing fertilizer Python package" \
   && pip install fertilizer \
   && echo "----- Preparing directories" \
   && mkdir /config /data /torrents \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 
@@ -7,7 +7,7 @@ COPY src src
 
 RUN apt-get update \
   && echo "----- Installing python requirements" \
-  && pip install uv \
+  && pip install --no-cache-dir uv \
   && uv pip install -r pyproject.toml --system --all-extras \
   && uv pip install -e . --system \
   && echo "----- Preparing directories" \


### PR DESCRIPTION
Debian Buster has been EOL'd and therefore future builds will not work for Docker containers. This PR switches the image to Bookworm.

This PR also changes from the actions using node20 (currently giving a deprecation warning) to updated actions using node24

When running this on my own fork everything built correctly and deployed, although I am obviously not able to deploy to pypi on a fork - but there seems to be only a version change which I think should cause zero issues.