### PR TITLE
Update cookie/response handling for qbittorrent 5.2.x and above

### DIFF
--- a/src/fertilizer/clients/qbittorrent.py
+++ b/src/fertilizer/clients/qbittorrent.py
@@ -77,7 +77,21 @@ class Qbittorrent(TorrentClient):
     except requests.RequestException as e:
       raise TorrentClientAuthenticationError(f"qBittorrent login failed: {e}")
 
-    self._qbit_cookie = response.cookies.get_dict().get("SID")
+    # qBittorrent returns "Fails." on bad credentials, "Ok." on success
+    # (older versions), and an empty 204 on success (5.2+). A non-empty
+    # body that isn't "Ok." indicates failure.
+    body = response.text.strip()
+    if body and body != "Ok.":
+      raise TorrentClientAuthenticationError("qBittorrent login failed: Invalid username or password")
+
+    # session cookied were previously named "SID". 5.2+ uses "QBT_SID_<port>".
+    cookies = response.cookies.get_dict()
+    self._qbit_cookie = cookies.get("SID") or next(
+      (value for name, value in cookies.items() if name.startswith("QBT_SID")),
+      None,
+    )
+
+    # check if the cookie has been successfully identified or raise.
     if not self._qbit_cookie:
       raise TorrentClientAuthenticationError("qBittorrent login failed: Invalid username or password")
 


### PR DESCRIPTION
the cookie "SID" has been updated in 5.2+ to be "QBIT_SID_<PORT>" and as a result the cookie check fails on all 5.2.x and future versions of qBittorrent

This PR updates the cookie check to consider the new name of the session token.

<hr>

Note: qBittorrent takes the first cookie regardless of the cookies key/name and passes if the key matches a valid token based on testing and looking at [the source for parseCookie in qBittorrent](https://github.com/qbittorrent/qBittorrent/blob/master/src/webui/webapplication.cpp#L90-L107) so mirroring the name/key in fertilizers cookies does not appear to matter, testing confirms this.