### PR TITLE
fix: replace lone surrogates in API filePath before building the output path

### DIFF
--- a/src/fertilizer/torrent.py
+++ b/src/fertilizer/torrent.py
@@ -116,11 +116,20 @@ def __generate_torrent_output_filepath(
   tracker_name = new_tracker.site_shortname()
   source_name = f" [{new_source}]" if new_source else ""
 
-  filepath_from_api_response = unescape(api_response["response"]["torrent"]["filePath"])
+  filepath_from_api_response = __replace_lone_surrogates(unescape(api_response["response"]["torrent"]["filePath"]))
   filename = f"{filepath_from_api_response}{source_name}.torrent"
   torrent_filepath = os.path.join(output_directory, tracker_name, filename)
 
   return torrent_filepath
+
+
+def __replace_lone_surrogates(value: str) -> str:
+  # Tracker APIs can return JSON containing lone surrogates (escaped invalid bytes
+  # from the original upload). Those cannot be encoded to UTF-8, so any filesystem
+  # call on a path containing them fails with "'utf-8' codec can't encode
+  # characters: surrogates not allowed". Replace them with U+FFFD and leave every
+  # valid character untouched.
+  return "".join("�" if "\ud800" <= char <= "\udfff" else char for char in value)
 
 
 def __get_torrent_id(api_response: dict) -> str:

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -117,6 +117,20 @@ class TestGenerateNewTorrentFromFile(SetupTeardown):
 
       os.remove(filepath)
 
+  def test_handles_lone_surrogates_in_api_filepath(self, red_api, ops_api):
+    with requests_mock.Mocker() as m:
+      response = {"status": "success", "response": {"torrent": {"filePath": "foo \ud83d bar", "id": 123}}}
+      m.get(re.compile("action=torrent"), json=response)
+      m.get(re.compile("action=index"), json=self.ANNOUNCE_SUCCESS_RESPONSE)
+
+      torrent_path = get_torrent_path("red_source")
+      _, filepath, _ = generate_new_torrent_from_file(torrent_path, "/tmp", red_api, ops_api)
+
+      assert "\ud83d" not in filepath
+      assert os.path.isfile(filepath)
+
+      os.remove(filepath)
+
   def test_raises_error_if_cannot_decode_torrent(self, red_api, ops_api):
     with pytest.raises(TorrentDecodingError) as excinfo:
       torrent_path = get_torrent_path("broken")


### PR DESCRIPTION
## What

Torrent files whose tracker API response contains lone surrogates in `filePath` crash the scan with:

```
'utf-8' codec can't encode characters in position 20-28: surrogates not allowed
```

Fixes #47

## Root cause

Gazelle APIs escape invalid bytes from the original upload as lone surrogates in the JSON (for example `"\ud83d"`). `json.loads()` in `api.py` decodes those escapes into unpaired surrogate characters inside the `filePath` string without complaining. The output filepath is built from that string, and the first filesystem call on it (`os.path.exists`, `open`) raises `UnicodeEncodeError`, because lone surrogates cannot be encoded to UTF-8.

## Fix

`__generate_torrent_output_filepath()` now replaces lone surrogates with U+FFFD (the Unicode replacement character) when building the output path. Every valid character, including non-ASCII names, passes through untouched. U+FFFD is a legal filename character on both POSIX filesystems and NTFS, so this also behaves on Windows (a plain `'?'` replacement would not).

## Test

Added `test_handles_lone_surrogates_in_api_filepath`: mocks a torrent API response whose `filePath` contains a lone surrogate and asserts the generated file lands on disk with a sanitized name. The test fails with the old code and passes with the fix. `ruff check` and `ruff format --check` are clean; the rest of the suite is unaffected.
