### PR TITLE
Fix four qBittorrent integration issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,20 @@ FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 
-COPY docker_start ./
+COPY docker_start pyproject.toml README.md ./
+COPY src ./src
 
 RUN echo "----- Installing build dependencies" \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
     build-essential \
     gcc
-    
-# Install build dependencies
+
+# Install fertilizer from the repository source so the image always ships
+# the code of the tagged commit (installing from PyPI raced the PyPI release
+# and could bake a stale, cached version into the image)
 RUN echo "----- Installing fertilizer Python package" \
-  && pip install fertilizer \
+  && pip install --no-cache-dir . \
   && echo "----- Preparing directories" \
   && mkdir /config /data /torrents \
   && echo "----- Cleanup" \

--- a/src/fertilizer/clients/qbittorrent.py
+++ b/src/fertilizer/clients/qbittorrent.py
@@ -84,10 +84,12 @@ class Qbittorrent(TorrentClient):
     if body and body != "Ok.":
       raise TorrentClientAuthenticationError("qBittorrent login failed: Invalid username or password")
 
-    # session cookied were previously named "SID". 5.2+ uses "QBT_SID_<port>".
+    # The session cookie was previously named "SID". 5.2+ uses "QBT_SID_<port>"
+    # and only accepts the session under that exact name, so we have to keep
+    # the cookie name around and echo it back verbatim on every request.
     cookies = response.cookies.get_dict()
-    self._qbit_cookie = cookies.get("SID") or next(
-      (value for name, value in cookies.items() if name.startswith("QBT_SID")),
+    self._qbit_cookie = next(
+      (f"{name}={value}" for name, value in cookies.items() if name == "SID" or name.startswith("QBT_SID")),
       None,
     )
 
@@ -108,7 +110,7 @@ class Qbittorrent(TorrentClient):
     try:
       response = requests.post(
         url_join(href, path),
-        headers=CaseInsensitiveDict({"Cookie": f"SID={self._qbit_cookie}"}),
+        headers=CaseInsensitiveDict({"Cookie": self._qbit_cookie}),
         data=data,
         files=files,
       )
@@ -117,7 +119,7 @@ class Qbittorrent(TorrentClient):
 
       return response.text
     except requests.RequestException as e:
-      if e.response.status_code == 403:
+      if e.response is not None and e.response.status_code == 403:
         print(e.response.text)
         raise TorrentClientAuthenticationError("Failed to authenticate with qBittorrent")
 

--- a/src/fertilizer/clients/qbittorrent.py
+++ b/src/fertilizer/clients/qbittorrent.py
@@ -35,7 +35,7 @@ class Qbittorrent(TorrentClient):
         "complete": torrent_completed,
         "label": torrent["category"],
         "save_path": torrent["save_path"],
-        "content_path": torrent["content_path"],
+        "content_path": self.__normalize_content_path(torrent["save_path"], torrent["content_path"]),
       }
     else:
       raise TorrentClientError("Client returned unexpected response")
@@ -64,6 +64,21 @@ class Qbittorrent(TorrentClient):
     self.__wrap_request("torrents/add", data=params, files=torrents)
 
     return new_torrent_infohash
+
+  @staticmethod
+  def __normalize_content_path(save_path, content_path):
+    # qBittorrent reports the absolute path of the file itself for any torrent
+    # containing a single file, even when that file lives inside a directory.
+    # Fertilizer expects the topmost file or directory of the torrent (which is
+    # what the Deluge and Transmission clients report), so walk the content
+    # path back up to the entry directly beneath the save path.
+    save = Path(save_path)
+    content = Path(content_path)
+
+    if not content.is_relative_to(save) or content.parent == save:
+      return content_path
+
+    return str(save / content.relative_to(save).parts[0])
 
   def __authenticate(self):
     href, username, password = self._qbit_url_parts

--- a/src/fertilizer/clients/qbittorrent.py
+++ b/src/fertilizer/clients/qbittorrent.py
@@ -55,6 +55,10 @@ class Qbittorrent(TorrentClient):
       "category": self._determine_label(source_torrent_info),
       "tags": self.torrent_label,
       "savepath": save_path_override if save_path_override else source_torrent_info["save_path"],
+      # The injected data is already complete at savepath, so the torrent must
+      # not be routed through the global "incomplete torrents" download path -
+      # otherwise qBittorrent rechecks in the wrong directory and re-downloads.
+      "useDownloadPath": False,
     }
 
     self.__wrap_request("torrents/add", data=params, files=torrents)

--- a/src/fertilizer/webserver.py
+++ b/src/fertilizer/webserver.py
@@ -4,7 +4,8 @@ import os
 from flask import Flask, request
 
 from fertilizer.errors import TorrentAlreadyExistsError, TorrentNotFoundError
-from fertilizer.parser import is_valid_infohash
+from fertilizer.filesystem import list_files_of_extension
+from fertilizer.parser import calculate_infohash, get_bencoded_data, is_valid_infohash
 from fertilizer.scanner import scan_torrent_file
 
 app = Flask(__name__)
@@ -34,7 +35,15 @@ def webhook():
   if not is_valid_infohash(infohash):
     return http_error("Invalid infohash", 400)
   if not os.path.exists(filepath):
-    return http_error(f"No torrent found at {filepath}", 404)
+    # Torrent clients don't necessarily export .torrent files named by
+    # infohash (e.g. qBittorrent's "Copy .torrent files to" uses the torrent
+    # name), so fall back to matching the files' actual infohashes.
+    fallback_filepath = __find_torrent_filepath_by_infohash(config["input_dir"], infohash)
+
+    if fallback_filepath is None:
+      return http_error(f"No torrent found at {filepath}", 404)
+
+    filepath = fallback_filepath
 
   try:
     new_filepath = scan_torrent_file(
@@ -57,6 +66,19 @@ def webhook():
 @app.errorhandler(404)
 def page_not_found(_e):
   return http_error("Not found", 404)
+
+
+def __find_torrent_filepath_by_infohash(input_directory: str, infohash: str) -> str | None:
+  for filepath in list_files_of_extension(input_directory, ".torrent"):
+    try:
+      torrent_data = get_bencoded_data(filepath)
+
+      if torrent_data and calculate_infohash(torrent_data) == infohash.upper():
+        return filepath
+    except Exception:
+      continue
+
+  return None
 
 
 def http_success(message, code):

--- a/tests/clients/test_qbittorrent.py
+++ b/tests/clients/test_qbittorrent.py
@@ -108,6 +108,36 @@ class TestGetTorrentInfo(SetupTeardown):
         "content_path": "/tmp/bar/foo",
       }
 
+  def test_returns_top_level_directory_for_single_file_in_directory(self, qbit_client, torrent_info_response):
+    torrent_info_response["content_path"] = "/tmp/bar/artist - album/01 track.flac"
+
+    with requests_mock.Mocker() as m:
+      m.post(re.compile("torrents/info"), json=[torrent_info_response])
+
+      response = qbit_client.get_torrent_info("1234")
+
+      assert response["content_path"] == "/tmp/bar/artist - album"
+
+  def test_returns_content_path_unchanged_for_bare_single_file(self, qbit_client, torrent_info_response):
+    torrent_info_response["content_path"] = "/tmp/bar/foo.flac"
+
+    with requests_mock.Mocker() as m:
+      m.post(re.compile("torrents/info"), json=[torrent_info_response])
+
+      response = qbit_client.get_torrent_info("1234")
+
+      assert response["content_path"] == "/tmp/bar/foo.flac"
+
+  def test_returns_content_path_unchanged_when_outside_save_path(self, qbit_client, torrent_info_response):
+    torrent_info_response["content_path"] = "/other/place/artist - album/01 track.flac"
+
+    with requests_mock.Mocker() as m:
+      m.post(re.compile("torrents/info"), json=[torrent_info_response])
+
+      response = qbit_client.get_torrent_info("1234")
+
+      assert response["content_path"] == "/other/place/artist - album/01 track.flac"
+
   def test_raises_exception_on_missing_torrent(self, qbit_client):
     with requests_mock.Mocker() as m:
       m.post(re.compile("torrents/info"), json=[])

--- a/tests/clients/test_qbittorrent.py
+++ b/tests/clients/test_qbittorrent.py
@@ -55,6 +55,35 @@ class TestSetup(SetupTeardown):
       assert response
       assert qbit_client._qbit_cookie is not None
 
+  def test_sets_auth_cookie_on_qbit_5_2(self, qbit_client):
+    with requests_mock.Mocker() as m:
+      m.post(re.compile("auth/login"), text="", headers={"Set-Cookie": "QBT_SID_8080=abcd;"})
+
+      response = qbit_client.setup()
+
+      assert response
+      assert qbit_client._qbit_cookie == "QBT_SID_8080=abcd"
+
+  def test_sends_session_cookie_name_back_on_requests(self, qbit_client, torrent_info_response):
+    with requests_mock.Mocker() as m:
+      m.post(re.compile("auth/login"), text="", headers={"Set-Cookie": "QBT_SID_8080=abcd;"})
+      m.post(re.compile("torrents/info"), json=[torrent_info_response])
+
+      qbit_client.setup()
+      qbit_client.get_torrent_info("infohash")
+
+      assert m.request_history[-1].headers["Cookie"] == "QBT_SID_8080=abcd"
+
+  def test_sends_legacy_sid_cookie_back_on_requests(self, qbit_client, torrent_info_response):
+    with requests_mock.Mocker() as m:
+      m.post(re.compile("auth/login"), text="Ok.", headers={"Set-Cookie": "SID=1234;"})
+      m.post(re.compile("torrents/info"), json=[torrent_info_response])
+
+      qbit_client.setup()
+      qbit_client.get_torrent_info("infohash")
+
+      assert m.request_history[-1].headers["Cookie"] == "SID=1234"
+
   def test_raises_exception_on_failed_auth(self, qbit_client):
     with requests_mock.Mocker() as m:
       m.post(re.compile("auth/login"), status_code=403)

--- a/tests/clients/test_qbittorrent.py
+++ b/tests/clients/test_qbittorrent.py
@@ -154,6 +154,7 @@ class TestInjectTorrent(SetupTeardown):
       assert b'name="category"\r\n\r\nfertilizer' in m.request_history[-1].body
       assert b'name="tags"\r\n\r\nfertilizer' in m.request_history[-1].body
       assert b'name="savepath"\r\n\r\n/tmp/bar/' in m.request_history[-1].body
+      assert b'name="useDownloadPath"\r\n\r\nFalse' in m.request_history[-1].body
 
   def test_uses_save_path_override_if_present(self, qbit_client, torrent_info_response):
     torrent_path = get_torrent_path("red_source")
@@ -166,6 +167,7 @@ class TestInjectTorrent(SetupTeardown):
 
       assert "torrents/add" in m.request_history[-1].url
       assert b'name="savepath"\r\n\r\n/tmp/override/' in m.request_history[-1].body
+      assert b'name="useDownloadPath"\r\n\r\nFalse' in m.request_history[-1].body
 
   def test_raises_if_source_torrent_isnt_found_in_client(self, qbit_client):
     with requests_mock.Mocker() as m:

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -5,6 +5,7 @@ import requests_mock
 
 from .helpers import SetupTeardown, get_torrent_path, copy_and_mkdir
 
+from fertilizer.parser import calculate_infohash, get_bencoded_data
 from fertilizer.webserver import app as webserver_app
 
 
@@ -73,6 +74,38 @@ class TestWebserverWebhook(SetupTeardown):
       assert response.status_code == 201
       assert response.json == {"status": "success", "message": "/tmp/output/OPS/foo [OPS].torrent"}
       assert os.path.exists("/tmp/output/OPS/foo [OPS].torrent")
+
+  def test_resolves_name_based_torrent_file_via_fallback(self, client):
+    source_path = copy_and_mkdir(get_torrent_path("red_source"), "/tmp/input/Some Album (2013) [FLAC].torrent")
+    real_infohash = calculate_infohash(get_bencoded_data(source_path)).lower()
+
+    with requests_mock.Mocker() as m:
+      m.get(re.compile("action=torrent"), json=self.TORRENT_SUCCESS_RESPONSE)
+      m.get(re.compile("action=index"), json=self.ANNOUNCE_SUCCESS_RESPONSE)
+
+      response = client.post("/api/webhook", data={"infohash": real_infohash})
+      assert response.status_code == 201
+      assert response.json == {"status": "success", "message": "/tmp/output/OPS/foo [OPS].torrent"}
+      assert os.path.exists("/tmp/output/OPS/foo [OPS].torrent")
+
+  def test_returns_404_when_no_torrent_matches_infohash(self, client, infohash):
+    copy_and_mkdir(get_torrent_path("red_source"), "/tmp/input/Some Album (2013) [FLAC].torrent")
+
+    response = client.post("/api/webhook", data={"infohash": infohash})
+    assert response.status_code == 404
+    assert response.json == {"status": "error", "message": f"No torrent found at /tmp/input/{infohash}.torrent"}
+
+  def test_fallback_skips_undecodable_torrent_files(self, client):
+    copy_and_mkdir(get_torrent_path("broken"), "/tmp/input/broken.torrent")
+    source_path = copy_and_mkdir(get_torrent_path("red_source"), "/tmp/input/Some Album (2013) [FLAC].torrent")
+    real_infohash = calculate_infohash(get_bencoded_data(source_path)).lower()
+
+    with requests_mock.Mocker() as m:
+      m.get(re.compile("action=torrent"), json=self.TORRENT_SUCCESS_RESPONSE)
+      m.get(re.compile("action=index"), json=self.ANNOUNCE_SUCCESS_RESPONSE)
+
+      response = client.post("/api/webhook", data={"infohash": real_infohash})
+      assert response.status_code == 201
 
   def test_returns_okay_if_torrent_already_found(self, client, infohash):
     copy_and_mkdir(get_torrent_path("red_source"), f"/tmp/input/{infohash}.torrent")


### PR DESCRIPTION
This PR bundles four fixes for running fertilizer against qBittorrent. Each fix is a separate, self-contained commit with tests, so feel free to cherry-pick or drop any of them.

Fixes #54, fixes #34, fixes #46, fixes #52.

## 1. qBittorrent 5.2.x: session cookie name must be preserved (#54)

#56 correctly extracts the session cookie *value* from the new `QBT_SID_<port>` cookie, but every subsequent request replays it as `Cookie: SID=<value>`. qBittorrent 5.2.x only resolves sessions under the exact new cookie name, so every API call after login gets a 403, the client re-authenticates (successfully — which is why qBittorrent's own log shows a successful WebAPI login), fails again, and the user ends up with the reported auth error. The fix stores the full `name=value` pair at login and echoes it back verbatim; older versions using `SID` keep working.

Also guards the 403 check in `__request` against exceptions that carry no response (connection errors previously raised `AttributeError` instead of a useful `TorrentClientError`).

### Why v0.3.2 still shipped the old behaviour (the Dockerfile commit)

The image installs fertilizer **unpinned from PyPI** at build time. The Docker Release and PyPI Release workflows start on the same tag push, so the docker build races the PyPI upload — and with `cache-from: type=gha`, the `pip install fertilizer` layer can be a cache hit from before the new version existed. That's exactly what happened for v0.3.2: the published **linux/amd64** image contains `fertilizer-0.3.0.dist-info` (pre-#56 code, verified by inspecting the GHCR layer), while linux/arm64 was rebuilt fresh and got 0.3.2. This explains the "upgraded and same issue" reports on #54.

The last commit builds the image from the repository source instead (`COPY src` + `pip install .`), which both guarantees the image ships the tagged code and invalidates the layer cache per commit. Note for the next release: re-tagging **without** this change could re-serve the stale cached amd64 layer.

## 2. Injected torrents re-download when a global download path is set (#34)

`torrents/add` was sent without `useDownloadPath`. With qBittorrent's *"Keep incomplete torrents in:"* option enabled, a freshly added torrent (0% at add time) is placed and rechecked in the global download path instead of the passed `savepath` — where fertilizer just hardlinked the complete data. The recheck finds nothing and the torrent starts downloading. Passing `useDownloadPath: False` makes the on-add check run against `savepath`, so the torrent verifies to 100% and seeds. The flag exists since qBittorrent 4.4.0; older versions ignore the unknown field.

## 3. Single-file torrents with a root folder are linked incorrectly (#46)

For any torrent containing exactly one file, qBittorrent's `content_path` points at the **file itself**, even when the torrent has a root folder. Injection consumes `content_path` as the torrent's topmost file-or-directory (the contract the Deluge and Transmission clients fulfil by synthesizing `save_path + name`), so fertilizer hardlinked only the bare file to `<link_dir>/<tracker>/01.flac` while the injected torrent expected `<link_dir>/<tracker>/Album/01.flac` — and re-downloaded. The fix normalizes `content_path` in the qBittorrent client back up to the entry directly beneath `save_path`. Multi-file torrents, bare single-file torrents, and paths outside `save_path` (relocated torrents) pass through unchanged.

## 4. Server mode can't find qBittorrent-exported .torrent files (#52)

The webhook only looks for `<input_dir>/<infohash>.torrent`, but qBittorrent's *"Copy .torrent files to"* feature names exported files after the torrent, with no option to change that — so server mode could never locate them. When the infohash-named file is absent, the webhook now falls back to scanning `input_dir` and matching each file's actual infohash (case-normalized: qBittorrent sends lowercase, `calculate_infohash` returns uppercase). Undecodable files are skipped, the happy path stays scan-free, and the 404 message is unchanged.

## Testing

- New tests for every fix (cookie name round-trip for `QBT_SID_<port>` and legacy `SID`, `useDownloadPath` in the add request, `content_path` normalization incl. pass-through cases, webhook fallback incl. no-match and broken-file cases).
- Full suite green on Linux (Python 3.11), ruff check + format clean.
