### PR TITLE
refactor: Dockerfile - multi-stage build + alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,33 @@
-FROM python:3.11-slim-bookworm
+FROM python:3.11-alpine AS builder
+
+RUN echo "----- Installing build dependencies" \
+  && apk add --no-cache \
+    linux-headers \
+    build-base
+
+COPY . .
+
+RUN echo '----- Making wheels dir in builder' \
+  && pip wheel --no-cache-dir --wheel-dir=/wheels .
+
+
+
+
+FROM python:3.11-alpine
 
 WORKDIR /app
 
-COPY docker_start ./
+COPY --from=builder /wheels /wheels
 
-RUN echo "----- Installing build dependencies" \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-    build-essential \
-    gcc
-    
-# Install build dependencies
-RUN echo "----- Installing fertilizer Python package" \
-  && pip install fertilizer \
+RUN echo "----- Installing wheels" \
+  && pip install --no-cache-dir /wheels/* \
+  && rm -rf /wheels \
   && echo "----- Preparing directories" \
-  && mkdir /config /data /torrents \
-  && echo "----- Cleanup" \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && mkdir /config /data /torrents
+
+COPY ./docker_start .
+
+RUN chmod +x ./docker_start
 
 EXPOSE 9713
-
 ENTRYPOINT ["./docker_start"]


### PR DESCRIPTION
## refactor: Dockerfile - multi-stage build + alpine

Refactors the `Dockerfile` to use a multi-stage build and switches the base image to Alpine, reducing final image size and improving build separation between dependencies/build steps and the runtime image.

Alpine wasn't really needed, but thought it would be nice to include as it makes the final image a lot smaller. 