### PR TITLE
Check client for existing torrent before linking files

### DIFF
--- a/src/fertilizer/clients/deluge.py
+++ b/src/fertilizer/clients/deluge.py
@@ -68,7 +68,7 @@ class Deluge(TorrentClient):
 
   def inject_torrent(self, source_torrent_infohash, new_torrent_filepath, save_path_override=None):
     new_torrent_infohash = calculate_infohash(get_bencoded_data(new_torrent_filepath)).lower()
-    new_torrent_already_exists = self.__does_torrent_exist_in_client(new_torrent_infohash)
+    new_torrent_already_exists = self.torrent_exists(new_torrent_infohash)
 
     if new_torrent_already_exists:
       raise TorrentExistsInClientError(f"New torrent already exists in client ({new_torrent_infohash})")
@@ -170,9 +170,3 @@ class Deluge(TorrentClient):
   def __handle_response_headers(self, headers):
     if "Set-Cookie" in headers:
       self._deluge_cookie = headers["Set-Cookie"].split(";")[0]
-
-  def __does_torrent_exist_in_client(self, infohash):
-    try:
-      return bool(self.get_torrent_info(infohash))
-    except TorrentClientError:
-      return False

--- a/src/fertilizer/clients/qbittorrent.py
+++ b/src/fertilizer/clients/qbittorrent.py
@@ -43,7 +43,7 @@ class Qbittorrent(TorrentClient):
   def inject_torrent(self, source_torrent_infohash, new_torrent_filepath, save_path_override=None):
     source_torrent_info = self.get_torrent_info(source_torrent_infohash)
     new_torrent_infohash = calculate_infohash(get_bencoded_data(new_torrent_filepath)).lower()
-    new_torrent_already_exists = self.__does_torrent_exist_in_client(new_torrent_infohash)
+    new_torrent_already_exists = self.torrent_exists(new_torrent_infohash)
 
     if new_torrent_already_exists:
       raise TorrentExistsInClientError(f"New torrent already exists in client ({new_torrent_infohash})")
@@ -122,9 +122,3 @@ class Qbittorrent(TorrentClient):
         raise TorrentClientAuthenticationError("Failed to authenticate with qBittorrent")
 
       raise TorrentClientError(f"qBittorrent request to '{path}' failed: {e}")
-
-  def __does_torrent_exist_in_client(self, infohash):
-    try:
-      return bool(self.get_torrent_info(infohash))
-    except TorrentClientError:
-      return False

--- a/src/fertilizer/clients/torrent_client.py
+++ b/src/fertilizer/clients/torrent_client.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlparse, unquote
 
+from fertilizer.errors import TorrentClientError
 from fertilizer.utils import url_join
 
 
@@ -15,6 +16,12 @@ class TorrentClient:
 
   def inject_torrent(self, *_args, **_kwargs):
     raise NotImplementedError
+
+  def torrent_exists(self, infohash):
+    try:
+      return bool(self.get_torrent_info(infohash))
+    except TorrentClientError:
+      return False
 
   def _extract_credentials_from_url(self, url, base_path=None):
     parsed_url = urlparse(url)

--- a/src/fertilizer/clients/transmission.py
+++ b/src/fertilizer/clients/transmission.py
@@ -75,7 +75,7 @@ class TransmissionBt(TorrentClient):
       raise TorrentClientError("Cannot inject a torrent that is not complete")
 
     new_torrent_infohash = calculate_infohash(get_bencoded_data(new_torrent_filepath)).lower()
-    new_torrent_already_exists = self.__does_torrent_exist_in_client(new_torrent_infohash)
+    new_torrent_already_exists = self.torrent_exists(new_torrent_infohash)
     if new_torrent_already_exists:
       raise TorrentExistsInClientError(f"New torrent already exists in client ({new_torrent_infohash})")
 
@@ -132,9 +132,3 @@ class TransmissionBt(TorrentClient):
         raise TorrentClientAuthenticationError("Failed to authenticate with TransmissionBt")
 
       raise TorrentClientError(f"TransmissionBt request to '{self._base_url}' for method '{method}' failed: {e}")
-
-  def __does_torrent_exist_in_client(self, infohash):
-    try:
-      return bool(self.get_torrent_info(infohash))
-    except TorrentClientError:
-      return False

--- a/src/fertilizer/injection.py
+++ b/src/fertilizer/injection.py
@@ -5,7 +5,7 @@ from .clients.deluge import Deluge
 from .clients.qbittorrent import Qbittorrent
 from .clients.transmission import TransmissionBt
 from .config import Config
-from .errors import TorrentInjectionError
+from .errors import TorrentExistsInClientError, TorrentInjectionError
 from .parser import calculate_infohash, get_bencoded_data
 
 
@@ -21,6 +21,11 @@ class Injection:
 
   def inject_torrent(self, source_torrent_filepath, new_torrent_filepath, new_tracker):
     source_torrent_data = get_bencoded_data(source_torrent_filepath)
+    new_torrent_infohash = calculate_infohash(get_bencoded_data(new_torrent_filepath)).lower()
+
+    if self.client.torrent_exists(new_torrent_infohash):
+      raise TorrentExistsInClientError(f"New torrent already exists in client ({new_torrent_infohash})")
+
     source_torrent_file_or_dir = self.__determine_source_torrent_data_location(source_torrent_data)
     output_location = self.__determine_output_location(source_torrent_file_or_dir, new_tracker)
     self.__link_files_to_output_location(source_torrent_file_or_dir, output_location)

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -8,7 +8,7 @@ from .helpers import get_torrent_path, get_support_file_path, copy_and_mkdir, Se
 from fertilizer.clients.deluge import Deluge
 from fertilizer.clients.qbittorrent import Qbittorrent
 from fertilizer.clients.transmission import TransmissionBt
-from fertilizer.errors import TorrentInjectionError
+from fertilizer.errors import TorrentExistsInClientError, TorrentInjectionError
 from fertilizer.injection import Injection
 
 
@@ -25,6 +25,7 @@ class ConfigMock:
 def injector():
   instance = Injection(ConfigMock())
   instance.client = MagicMock()
+  instance.client.torrent_exists.return_value = False
   return instance
 
 
@@ -164,3 +165,29 @@ class TestInjectTorrent(SetupTeardown):
       injector.inject_torrent(source_torrent_filepath, new_torrent_filepath, "OPS")
 
     assert str(excinfo.value) == f"Cannot link given torrent since it's already been linked: {parent_dir}"
+
+  def test_raises_error_without_linking_if_new_torrent_already_in_client(self, injector):
+    source_torrent_filepath = copy_and_mkdir(get_torrent_path("red_source"), "/tmp/input/red_source.torrent")
+    new_torrent_filepath = copy_and_mkdir(get_torrent_path("ops_source"), "/tmp/output/ops_source.torrent")
+    copy_and_mkdir(get_support_file_path("foo.txt"), "/tmp/input/Big Buck Bunny/foo.txt")
+    injector.client.get_torrent_info.return_value = {"content_path": "/tmp/input/Big Buck Bunny"}
+    injector.client.torrent_exists.return_value = True
+
+    with pytest.raises(TorrentExistsInClientError) as excinfo:
+      injector.inject_torrent(source_torrent_filepath, new_torrent_filepath, "OPS")
+
+    assert str(excinfo.value) == "New torrent already exists in client (2aee440cdc7429b3e4a7e4d20e3839dbb48d72c2)"
+    assert not os.path.exists("/tmp/injection/OPS/Big Buck Bunny")
+    injector.client.inject_torrent.assert_not_called()
+
+  def test_checks_client_for_new_torrent_before_linking(self, injector):
+    source_torrent_filepath = copy_and_mkdir(get_torrent_path("red_source"), "/tmp/input/red_source.torrent")
+    new_torrent_filepath = copy_and_mkdir(get_torrent_path("ops_source"), "/tmp/output/ops_source.torrent")
+    copy_and_mkdir(get_support_file_path("foo.txt"), "/tmp/input/Big Buck Bunny/foo.txt")
+    injector.client.get_torrent_info.return_value = {"content_path": "/tmp/input/Big Buck Bunny"}
+
+    injector.inject_torrent(source_torrent_filepath, new_torrent_filepath, "OPS")
+
+    injector.client.torrent_exists.assert_called_once_with("2aee440cdc7429b3e4a7e4d20e3839dbb48d72c2")
+    assert os.path.exists("/tmp/injection/OPS/Big Buck Bunny/foo.txt")
+    injector.client.inject_torrent.assert_called_once()


### PR DESCRIPTION
## Problem

As described in #40: when the new torrent's infohash already exists in the client, `Injection.inject_torrent` still hardlinks the source data into the link directory first. The subsequent `client.inject_torrent` call then raises `TorrentExistsInClientError`, but by that point the links have already been created and are left orphaned.

Root cause: the duplicate-infohash check lived only inside each client's `inject_torrent` (as a private `__does_torrent_exist_in_client`), which runs *after* `Injection.__link_files_to_output_location`.

## Fix

- Promote the duplicate check to the `TorrentClient` interface as a public `torrent_exists(infohash)`. All three clients (Deluge, qBittorrent, Transmission) had byte-identical private implementations (`get_torrent_info` truthiness, `TorrentClientError` → `False`), so the shared base-class method replaces the three private copies; the clients' in-inject checks now call it and remain in place as defence in depth.
- In `Injection.inject_torrent`, compute the new torrent's infohash (`calculate_infohash(get_bencoded_data(new_torrent_filepath)).lower()`, exactly as the clients do) and raise `TorrentExistsInClientError` *before* any linking happens. No files are touched when the torrent is already in the client.

## Why callers need no change

The early check raises the same `TorrentExistsInClientError` with the same message format the clients already raise, just earlier. `scanner.py` already catches it and reports "already exists", and the webserver path surfaces it through the existing generic handler — both are unchanged.

## Tests

- `test_raises_error_without_linking_if_new_torrent_already_in_client`: duplicate case raises, creates no links in the link directory, and never calls the client's `inject_torrent`.
- `test_checks_client_for_new_torrent_before_linking`: non-duplicate case queries `torrent_exists` with the lowercased new infohash and still links and injects as before.
- Existing injection, scanner, webserver, and client test suites pass unchanged.

Fixes #40