### PR TITLE
Preserve URL path prefix when building client API URLs

### DIFF
--- a/src/fertilizer/clients/torrent_client.py
+++ b/src/fertilizer/clients/torrent_client.py
@@ -23,8 +23,10 @@ class TorrentClient:
     host = f"{parsed_url.hostname}{(':' + str(parsed_url.port)) if parsed_url.port else ''}"
     origin = f"{parsed_url.scheme}://{host}"
 
-    if base_path is not None:
-      href = url_join(origin, base_path)
+    # Preserve any path prefix in the configured URL (e.g. a reverse proxy) but
+    # avoid doubling the base path if the URL already ends with it.
+    if base_path is not None and not f"/{url_join(parsed_url.path)}".endswith(f"/{url_join(base_path)}"):
+      href = url_join(origin, parsed_url.path, base_path)
     else:
       href = url_join(origin, parsed_url.path)
 

--- a/tests/clients/test_qbittorrent.py
+++ b/tests/clients/test_qbittorrent.py
@@ -42,6 +42,16 @@ class TestInit(SetupTeardown):
 
     assert qbit_client._qbit_url_parts == ("http://localhost/api/v2", "admin", "supersecret")
 
+  def test_initializes_with_path_prefix(self):
+    qbit_client = Qbittorrent("http://admin:supersecret@localhost:8080/proxy/apikey")
+
+    assert qbit_client._qbit_url_parts == ("http://localhost:8080/proxy/apikey/api/v2", "admin", "supersecret")
+
+  def test_initializes_with_url_already_containing_base_path(self):
+    qbit_client = Qbittorrent("http://admin:supersecret@localhost:8080/api/v2")
+
+    assert qbit_client._qbit_url_parts == ("http://localhost:8080/api/v2", "admin", "supersecret")
+
 
 class TestSetup(SetupTeardown):
   def test_sets_auth_cookie(self, qbit_client):

--- a/tests/clients/test_transmission.py
+++ b/tests/clients/test_transmission.py
@@ -39,6 +39,20 @@ class TestInit(SetupTeardown):
     assert transmission_client._basic_auth.username == "admin"
     assert transmission_client._basic_auth.password == "supersecret"
 
+  def test_initializes_with_path_prefix(self):
+    transmission_client = TransmissionBt("http://admin:supersecret@localhost:51314/proxy")
+
+    assert transmission_client._base_url == "http://localhost:51314/proxy/transmission/rpc"
+    assert transmission_client._basic_auth.username == "admin"
+    assert transmission_client._basic_auth.password == "supersecret"
+
+  def test_initializes_with_url_already_containing_base_path(self):
+    transmission_client = TransmissionBt("http://admin:supersecret@localhost:51314/transmission/rpc")
+
+    assert transmission_client._base_url == "http://localhost:51314/transmission/rpc"
+    assert transmission_client._basic_auth.username == "admin"
+    assert transmission_client._basic_auth.password == "supersecret"
+
 
 class TestSetup(SetupTeardown):
   def test_sets_session_id(self, transmission_client):


### PR DESCRIPTION
## Root cause

`TorrentClient._extract_credentials_from_url` rebuilds the client URL from scheme + host only whenever a `base_path` is given (the qBittorrent and Transmission code paths):

```python
if base_path is not None:
  href = url_join(origin, base_path)
```

Any path in the configured URL is silently dropped. With a reverse-proxied client URL such as Qui's `http://ip:port/proxy/apikey`, fertilizer therefore requests `http://ip:port/api/v2/auth/login` instead of `http://ip:port/proxy/apikey/api/v2/auth/login` and fails with:

```
qBittorrent login failed: 404 Client Error: Not Found for url: http://ip:port/api/v2/auth/login
```

## Fix

Keep `parsed_url.path` when appending the base path:

```python
if base_path is not None and not f"/{url_join(parsed_url.path)}".endswith(f"/{url_join(base_path)}"):
  href = url_join(origin, parsed_url.path, base_path)
else:
  href = url_join(origin, parsed_url.path)
```

The ends-with guard compares slash-normalized paths so a URL that already ends in the base path (`…/api/v2`, `…/transmission/rpc`) is not doubled, and the leading `/` keeps the comparison on segment boundaries (`/myapi/v2` is not treated as ending in `/api/v2`).

## Why existing setups are unaffected

- URLs without a path produce byte-identical hrefs: `url_join` discards empty segments, so `url_join(origin, "", base_path) == url_join(origin, base_path)` (and a bare `/` path normalizes to empty as well). The pre-existing `TestInit` cases for both clients pass unchanged.
- Deluge passes no `base_path` and keeps the unchanged `url_join(origin, parsed_url.path)` branch.
- New tests cover the prefixed-path case and the already-contains-base-path case for both qBittorrent and Transmission.

Fixes #50