### PR TITLE
Make injection torrent label configurable

### DIFF
--- a/src/fertilizer/clients/deluge.py
+++ b/src/fertilizer/clients/deluge.py
@@ -16,8 +16,8 @@ class Deluge(TorrentClient):
     "NO_AUTH": 1,
   }
 
-  def __init__(self, rpc_url):
-    super().__init__()
+  def __init__(self, rpc_url, torrent_label="fertilizer"):
+    super().__init__(torrent_label)
     self._rpc_url = rpc_url
     self._deluge_cookie = None
     self._deluge_request_id = 0
@@ -79,7 +79,7 @@ class Deluge(TorrentClient):
       raise TorrentClientError("Cannot inject a torrent that is not complete")
 
     params = [
-      f"{Path(new_torrent_filepath).stem}.fertilizer.torrent",
+      f"{Path(new_torrent_filepath).stem}.{self.torrent_label}.torrent",
       base64.b64encode(open(new_torrent_filepath, "rb").read()).decode("utf-8"),
       {
         "download_location": save_path_override if save_path_override else source_torrent_info["save_path"],

--- a/src/fertilizer/clients/qbittorrent.py
+++ b/src/fertilizer/clients/qbittorrent.py
@@ -10,8 +10,8 @@ from .torrent_client import TorrentClient
 
 
 class Qbittorrent(TorrentClient):
-  def __init__(self, qbit_url):
-    super().__init__()
+  def __init__(self, qbit_url, torrent_label="fertilizer"):
+    super().__init__(torrent_label)
     self._qbit_url_parts = self._extract_credentials_from_url(qbit_url, "/api/v2")
     self._qbit_cookie = None
 
@@ -48,7 +48,7 @@ class Qbittorrent(TorrentClient):
     if new_torrent_already_exists:
       raise TorrentExistsInClientError(f"New torrent already exists in client ({new_torrent_infohash})")
 
-    injection_filename = f"{Path(new_torrent_filepath).stem}.fertilizer.torrent"
+    injection_filename = f"{Path(new_torrent_filepath).stem}.{self.torrent_label}.torrent"
     torrents = {"torrents": (injection_filename, open(new_torrent_filepath, "rb"), "application/x-bittorrent")}
     params = {
       "autoTMM": False,

--- a/src/fertilizer/clients/torrent_client.py
+++ b/src/fertilizer/clients/torrent_client.py
@@ -4,8 +4,8 @@ from fertilizer.utils import url_join
 
 
 class TorrentClient:
-  def __init__(self):
-    self.torrent_label = "fertilizer"
+  def __init__(self, torrent_label="fertilizer"):
+    self.torrent_label = torrent_label
 
   def setup(self):
     raise NotImplementedError

--- a/src/fertilizer/clients/transmission.py
+++ b/src/fertilizer/clients/transmission.py
@@ -27,8 +27,8 @@ class StatusEnum(Enum):
 class TransmissionBt(TorrentClient):
   X_TRANSMISSION_SESSION_ID = "X-Transmission-Session-Id"
 
-  def __init__(self, rpc_url):
-    super().__init__()
+  def __init__(self, rpc_url, torrent_label="fertilizer"):
+    super().__init__(torrent_label)
     transmission_url_parts = self._extract_credentials_from_url(rpc_url, "transmission/rpc")
     self._base_url = transmission_url_parts[0]
     self._basic_auth = HTTPBasicAuth(transmission_url_parts[1], transmission_url_parts[2])

--- a/src/fertilizer/config.json
+++ b/src/fertilizer/config.json
@@ -1,4 +1,5 @@
 {
   "red_key": "",
-  "ops_key": ""
+  "ops_key": "",
+  "torrent_label": ""
 }

--- a/src/fertilizer/config.py
+++ b/src/fertilizer/config.py
@@ -26,6 +26,7 @@ class Config:
         "transmission_rpc_url": env_vars.get("TRANSMISSION_RPC_URL"),
         "qbittorrent_url": env_vars.get("QBITTORRENT_URL"),
         "injection_link_directory": env_vars.get("INJECTION_LINK_DIRECTORY"),
+        "torrent_label": env_vars.get("TORRENT_LABEL"),
       }.items()
       if value
     }
@@ -66,3 +67,7 @@ class Config:
   @property
   def injection_link_directory(self) -> str | None:
     return self._config.get("injection_link_directory")
+
+  @property
+  def torrent_label(self) -> str:
+    return self._config.get("torrent_label", "fertilizer")

--- a/src/fertilizer/config_validator.py
+++ b/src/fertilizer/config_validator.py
@@ -20,6 +20,7 @@ class ConfigValidator:
       "qbittorrent_url": self.__is_valid_qbit_url,
       "inject_torrents": self.__is_boolean,
       "injection_link_directory": assert_path_exists,
+      "torrent_label": self.__is_valid_torrent_label,
     }
 
   @staticmethod
@@ -115,6 +116,15 @@ class ConfigValidator:
     if coerced in ["true", "false"]:
       return coerced == "true"
     raise ValueError('value is not boolean ("true" or "false")')
+
+  @staticmethod
+  def __is_valid_torrent_label(label):
+    stripped = label.strip()
+    if not stripped:
+      raise ValueError('Invalid "torrent_label": Cannot be empty')
+    if "/" in stripped or "\\" in stripped:
+      raise ValueError(f'Invalid "torrent_label" ({label}): Cannot contain path separators')
+    return stripped
 
   @staticmethod
   def __is_valid_port(port):

--- a/src/fertilizer/injection.py
+++ b/src/fertilizer/injection.py
@@ -48,11 +48,11 @@ class Injection:
   @staticmethod
   def __determine_torrent_client(config: Config):
     if config.deluge_rpc_url:
-      return Deluge(config.deluge_rpc_url)
+      return Deluge(config.deluge_rpc_url, config.torrent_label)
     elif config.transmission_rpc_url:
-      return TransmissionBt(config.transmission_rpc_url)
+      return TransmissionBt(config.transmission_rpc_url, config.torrent_label)
     elif config.qbittorrent_url:
-      return Qbittorrent(config.qbittorrent_url)
+      return Qbittorrent(config.qbittorrent_url, config.torrent_label)
 
   # If the torrent is a single bare file, this returns the path _to that file_
   # If the torrent is one or many files in a directory, this returns the topmost directory path

--- a/tests/clients/test_deluge.py
+++ b/tests/clients/test_deluge.py
@@ -338,6 +338,38 @@ class TestInjectTorrent(SetupTeardown):
       assert m.request_history[-1].json()["params"] == ["abc123", "fertilizer"]
       assert m.request_history[-1].json()["method"] == "label.set_torrent"
 
+  def test_uses_custom_torrent_label(self, api_url, torrent_info_response):
+    torrent_path = get_torrent_path("red_source")
+    deluge_client = Deluge("http://:supersecret@localhost:8112/json", "fert")
+    deluge_client._label_plugin_enabled = True
+    torrent_info_response["label"] = ""
+
+    with requests_mock.Mocker() as m:
+      m.post(
+        api_url,
+        [
+          {"json": {"result": {"torrents": {}}}},
+          {
+            "json": {
+              "result": {
+                "torrents": {"foo": torrent_info_response},
+              },
+            }
+          },
+        ],
+        additional_matcher=torrent_info_matcher,
+      )
+
+      m.post(api_url, additional_matcher=add_torrent_matcher, json={"result": "abc123"})
+      m.post(api_url, additional_matcher=get_labels_matcher, json={"result": []})
+      m.post(api_url, additional_matcher=add_label_matcher, json={"result": []})
+      m.post(api_url, additional_matcher=apply_label_matcher, json={"result": True})
+
+      deluge_client.inject_torrent("foo", torrent_path)
+
+      assert m.request_history[2].json()["params"][0] == "red_source.fert.torrent"
+      assert m.request_history[-1].json()["params"] == ["abc123", "fert"]
+
   def test_adds_label_if_doesnt_exist(self, api_url, deluge_client, torrent_info_response):
     torrent_path = get_torrent_path("red_source")
     deluge_client._label_plugin_enabled = True

--- a/tests/clients/test_qbittorrent.py
+++ b/tests/clients/test_qbittorrent.py
@@ -138,6 +138,21 @@ class TestInjectTorrent(SetupTeardown):
       assert "torrents/add" in m.request_history[-1].url
       assert b'name="savepath"\r\n\r\n/tmp/override/' in m.request_history[-1].body
 
+  def test_uses_custom_torrent_label(self, torrent_info_response):
+    torrent_path = get_torrent_path("red_source")
+    qbit_client = Qbittorrent("http://admin:supersecret@localhost:8080", "fert")
+    torrent_info_response["category"] = ""
+
+    with requests_mock.Mocker() as m:
+      m.post(re.compile("torrents/info"), [{"json": [torrent_info_response]}, {"json": []}])
+      m.post(re.compile("torrents/add"), json={"hash": "1234"})
+
+      qbit_client.inject_torrent("foo", torrent_path)
+
+      assert b'filename="red_source.fert.torrent"' in m.request_history[-1].body
+      assert b'name="category"\r\n\r\nfert' in m.request_history[-1].body
+      assert b'name="tags"\r\n\r\nfert' in m.request_history[-1].body
+
   def test_raises_if_source_torrent_isnt_found_in_client(self, qbit_client):
     with requests_mock.Mocker() as m:
       m.post(re.compile("torrents/info"), json=[])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,12 @@ class TestConfig(SetupTeardown):
   def test_returns_default_value_if_present(self):
     assert Config({}).server_port == "9713"
 
+  def test_returns_default_torrent_label_if_absent(self):
+    assert Config({}).torrent_label == "fertilizer"
+
+  def test_returns_configured_torrent_label(self):
+    assert Config({"torrent_label": "fert"}).torrent_label == "fert"
+
 
 class TestBuildFromSources(SetupTeardown):
   def test_builds_from_config_file(self):
@@ -32,6 +38,7 @@ class TestBuildFromSources(SetupTeardown):
         "QBITTORRENT_URL": "http://qbittorrent:8080",
         "INJECT_TORRENTS": "true",
         "INJECTION_LINK_DIRECTORY": "/my/cool/dir",
+        "TORRENT_LABEL": "fert",
       },
     )
 
@@ -42,6 +49,7 @@ class TestBuildFromSources(SetupTeardown):
     assert config_dict["qbittorrent_url"] == "http://qbittorrent:8080"
     assert config_dict["inject_torrents"]
     assert config_dict["injection_link_directory"] == "/my/cool/dir"
+    assert config_dict["torrent_label"] == "fert"
 
   def test_config_file_takes_precedence_over_env(self):
     config_dict = Config.build_config_dict("tests/support/config.json", {"RED_KEY": "env_red_key"})

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -25,6 +25,7 @@ def valid_config(red_key, ops_key):
     "deluge_rpc_url": "http://:pass@deluge:8112",
     "inject_torrents": "true",
     "injection_link_directory": "/tmp/injection",
+    "torrent_label": "fert",
   }
 
 
@@ -51,6 +52,7 @@ class TestValidate(SetupTeardown):
       "deluge_rpc_url": "http://:pass@deluge:8112",
       "inject_torrents": True,
       "injection_link_directory": "/tmp/injection",
+      "torrent_label": "fert",
     }
 
   def test_raises_error_when_required_key_missing(self):
@@ -147,6 +149,29 @@ class TestValidate(SetupTeardown):
       validator.validate()
 
     assert '- "inject_torrents": value is not boolean ("true" or "false")' in str(excinfo.value)
+
+  def test_raises_if_torrent_label_is_empty(self, valid_config):
+    valid_config["torrent_label"] = "  "
+
+    validator = ConfigValidator(valid_config)
+
+    with pytest.raises(ValueError) as excinfo:
+      validator.validate()
+
+    assert '- "torrent_label": Invalid "torrent_label": Cannot be empty' in str(excinfo.value)
+
+  def test_raises_if_torrent_label_contains_path_separators(self, valid_config):
+    for label in ["fert/lizer", "fert\\lizer"]:
+      valid_config["torrent_label"] = label
+
+      validator = ConfigValidator(valid_config)
+
+      with pytest.raises(ValueError) as excinfo:
+        validator.validate()
+
+      assert f'- "torrent_label": Invalid "torrent_label" ({label}): Cannot contain path separators' in str(
+        excinfo.value
+      )
 
   def test_raises_if_injection_directory_doesnt_exist(self, valid_config):
     valid_config["injection_link_directory"] = "/tmp/doesnt_exist"

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -19,6 +19,7 @@ class ConfigMock:
     self.deluge_rpc_url = "http://:pass@localhost:8112/json"
     self.transmission_rpc_url = "http://:pass@localhost:51413/transmission/rpc"
     self.qbittorrent_url = "http://localhost:8080"
+    self.torrent_label = "fertilizer"
 
 
 @pytest.fixture
@@ -75,6 +76,26 @@ class TestInjection(SetupTeardown):
     assert isinstance(Injection(deluge_config).client, Deluge)
     assert isinstance(Injection(qbit_config).client, Qbittorrent)
     assert isinstance(Injection(transmission_config).client, TransmissionBt)
+
+  def test_passes_torrent_label_to_torrent_client(self):
+    deluge_config = ConfigMock()
+    deluge_config.qbittorrent_url = None
+    deluge_config.transmission_rpc_url = None
+    deluge_config.torrent_label = "fert"
+
+    qbit_config = ConfigMock()
+    qbit_config.deluge_rpc_url = None
+    qbit_config.transmission_rpc_url = None
+    qbit_config.torrent_label = "fert"
+
+    transmission_config = ConfigMock()
+    transmission_config.deluge_rpc_url = None
+    transmission_config.qbittorrent_url = None
+    transmission_config.torrent_label = "fert"
+
+    assert Injection(deluge_config).client.torrent_label == "fert"
+    assert Injection(qbit_config).client.torrent_label == "fert"
+    assert Injection(transmission_config).client.torrent_label == "fert"
 
 
 class TestSetup(SetupTeardown):


### PR DESCRIPTION
## What

Adds a new optional `torrent_label` config key (also settable via the `TORRENT_LABEL` environment variable) that controls:

- the label applied to injected torrents in Deluge (Label plugin) and the category/tag applied in qBittorrent, and
- the suffix appended to the injected torrent's filename, e.g. `Foo.fert.torrent` instead of `Foo.fertilizer.torrent`.

Label and filename suffix always stay consistent since they come from the same setting.

## Why

Requested in #27 (#28 was closed as a duplicate of it): people want injected torrents to land under their own label (e.g. an existing `cross-seed` label) or with a shorter suffix like `.fert`.

## Details

- `Config` gains a `torrent_label` property defaulting to `"fertilizer"`; `build_config_dict` picks up `TORRENT_LABEL` from the environment (the config file still takes precedence, as with the other keys).
- `ConfigValidator` validates the value as a non-empty string without path separators (it becomes part of a filename).
- `Injection.__determine_torrent_client` passes the configured label into the client constructors; `TorrentClient.__init__` takes the label as a parameter (still defaulting to `"fertilizer"`).
- The hardcoded `.fertilizer` filename suffixes in the Deluge and qBittorrent clients now use the configured label. TransmissionBt accepts the parameter for consistency; its injection keeps copying the source torrent's labels, unchanged.
- The bundled sample `src/fertilizer/config.json` includes the new key (empty, so the default applies).
- Tests added for the config property, the env var, the validator rules, the constructor wiring in `Injection`, and the custom label/suffix in the Deluge and qBittorrent clients.

**Default behaviour is unchanged**: without the new key, everything still uses `fertilizer` for the label, category, tag, and filename suffix.

The README doesn't document config keys (the wiki does), so no README change was needed. Happy to suggest wording for a wiki config-table row, e.g.: `torrent_label` — optional, default `fertilizer` — label/category applied to injected torrents and suffix used for injected torrent filenames.

Closes #27