### PR TITLE
feat(clients): add rTorrent injection support (XMLRPC)

### DIFF
--- a/src/fertilizer/clients/rtorrent.py
+++ b/src/fertilizer/clients/rtorrent.py
@@ -1,0 +1,116 @@
+import xmlrpc.client
+
+import requests
+from requests.auth import HTTPBasicAuth
+from requests.exceptions import RequestException
+
+from ..filesystem import sane_join
+from ..parser import get_bencoded_data, calculate_infohash
+from ..errors import TorrentClientError, TorrentClientAuthenticationError, TorrentExistsInClientError
+from .torrent_client import TorrentClient
+
+
+class RTorrent(TorrentClient):
+  # rTorrent's native transport is SCGI, but it is almost always fronted by an
+  # HTTP XMLRPC endpoint (ruTorrent's RPC2 mount, flood, or an nginx SCGIMount).
+  # We speak that HTTP XMLRPC over requests, like every other client here, so the
+  # config URL looks the same: http(s)://[user:pass@]host[:port]/RPC2
+  #
+  # rTorrent identifies torrents by an UPPERCASE hex infohash and stores the
+  # ruTorrent-style label in d.custom1.
+  def __init__(self, rpc_url):
+    super().__init__()
+    href, username, password = self._extract_credentials_from_url(rpc_url)
+    self._url = href
+    self._basic_auth = HTTPBasicAuth(username, password) if (username or password) else None
+
+  def setup(self):
+    # A cheap round-trip every rTorrent build supports; also proves the HTTP
+    # XMLRPC endpoint is reachable and authenticated.
+    version = self.__request("system.client_version")
+    if not version:
+      raise TorrentClientError("Reached the rTorrent RPC endpoint but got no version back")
+    return version
+
+  def get_torrent_info(self, infohash):
+    infohash = infohash.upper()
+
+    try:
+      complete = self.__request("d.complete", infohash)
+      directory = self.__request("d.directory", infohash)
+      base_path = self.__request("d.base_path", infohash)
+      name = self.__request("d.name", infohash)
+      label = self.__request("d.custom1", infohash)
+    except TorrentClientError as not_found_error:
+      # rTorrent raises a fault (mapped to TorrentClientError) for an unknown hash.
+      raise TorrentClientError(f"Torrent not found in client ({infohash})") from not_found_error
+
+    return {
+      "complete": bool(int(complete)),
+      "label": label or None,
+      "save_path": directory,
+      "content_path": base_path or sane_join(directory, name),
+    }
+
+  def inject_torrent(self, source_torrent_infohash, new_torrent_filepath, save_path_override=None):
+    new_torrent_infohash = calculate_infohash(get_bencoded_data(new_torrent_filepath)).upper()
+
+    if self.__does_torrent_exist_in_client(new_torrent_infohash):
+      raise TorrentExistsInClientError(f"New torrent already exists in client ({new_torrent_infohash})")
+
+    source_torrent_info = self.get_torrent_info(source_torrent_infohash)
+    if not source_torrent_info["complete"]:
+      raise TorrentClientError("Cannot inject a torrent that is not complete")
+
+    save_path = save_path_override if save_path_override else source_torrent_info["save_path"]
+    newtorrent_label = self._determine_label(source_torrent_info)
+
+    with open(new_torrent_filepath, "rb") as torrent_file:
+      torrent_data = xmlrpc.client.Binary(torrent_file.read())
+
+    # load.raw_start: (target, raw torrent bytes, *commands run before start). The
+    # commands set the data directory and the label (d.custom1) before the hash
+    # check, so the files fertilizer just linked are found and the torrent seeds.
+    self.__request(
+      "load.raw_start",
+      "",
+      torrent_data,
+      f"d.directory.set={save_path}",
+      f"d.custom1.set={newtorrent_label}",
+    )
+
+    return new_torrent_infohash.lower()
+
+  def __does_torrent_exist_in_client(self, infohash):
+    try:
+      return bool(self.get_torrent_info(infohash))
+    except TorrentClientError:
+      return False
+
+  def __request(self, method, *params):
+    xml_body = xmlrpc.client.dumps(tuple(params), method)
+
+    try:
+      response = requests.post(
+        self._url,
+        data=xml_body,
+        headers={"Content-Type": "text/xml"},
+        auth=self._basic_auth,
+        timeout=10,
+      )
+    except RequestException as network_error:
+      raise TorrentClientError(f"Failed to connect to rTorrent at {self._url}") from network_error
+
+    if response.status_code == 401:
+      raise TorrentClientAuthenticationError("Failed to authenticate with rTorrent")
+    if response.status_code != 200:
+      raise TorrentClientError(f"rTorrent method {method} returned HTTP {response.status_code}")
+
+    try:
+      result, _method_name = xmlrpc.client.loads(response.content)
+    except xmlrpc.client.Fault as fault:
+      raise TorrentClientError(f"rTorrent method {method} returned a fault: {fault.faultString}") from fault
+    except Exception as parse_error:
+      raise TorrentClientError(f"rTorrent method {method} returned a non-XMLRPC response") from parse_error
+
+    return result[0] if result else None

--- a/src/fertilizer/config.py
+++ b/src/fertilizer/config.py
@@ -25,6 +25,7 @@ class Config:
         "deluge_rpc_url": env_vars.get("DELUGE_RPC_URL"),
         "transmission_rpc_url": env_vars.get("TRANSMISSION_RPC_URL"),
         "qbittorrent_url": env_vars.get("QBITTORRENT_URL"),
+        "rtorrent_rpc_url": env_vars.get("RTORRENT_RPC_URL"),
         "injection_link_directory": env_vars.get("INJECTION_LINK_DIRECTORY"),
       }.items()
       if value
@@ -58,6 +59,10 @@ class Config:
   @property
   def qbittorrent_url(self) -> ParseResult | None:
     return self._config.get("qbittorrent_url")
+
+  @property
+  def rtorrent_rpc_url(self) -> ParseResult | None:
+    return self._config.get("rtorrent_rpc_url")
 
   @property
   def inject_torrents(self) -> bool:

--- a/src/fertilizer/config_validator.py
+++ b/src/fertilizer/config_validator.py
@@ -7,7 +7,7 @@ from .filesystem import assert_path_exists
 
 class ConfigValidator:
   REQUIRED_KEYS = ["red_key", "ops_key"]
-  TORRENT_CLIENT_KEYS = ["deluge_rpc_url", "transmission_rpc_url", "qbittorrent_url"]
+  TORRENT_CLIENT_KEYS = ["deluge_rpc_url", "transmission_rpc_url", "qbittorrent_url", "rtorrent_rpc_url"]
 
   def __init__(self, config_dict):
     self.config_dict = config_dict
@@ -18,6 +18,7 @@ class ConfigValidator:
       "deluge_rpc_url": self.__is_valid_deluge_url,
       "transmission_rpc_url": self.__is_valid_transmission_rpc_url,
       "qbittorrent_url": self.__is_valid_qbit_url,
+      "rtorrent_rpc_url": self.__is_valid_rtorrent_url,
       "inject_torrents": self.__is_boolean,
       "injection_link_directory": assert_path_exists,
     }
@@ -86,6 +87,13 @@ class ConfigValidator:
     if parsed_url.scheme and parsed_url.netloc:
       return parsed_url.geturl()  # return the parsed URL
     raise ValueError(f'Invalid "qbittorrent_url" provided: {url}')
+
+  @staticmethod
+  def __is_valid_rtorrent_url(url):
+    parsed_url = urlparse(url)
+    if parsed_url.scheme and parsed_url.netloc:
+      return parsed_url.geturl()  # return the parsed URL
+    raise ValueError(f'Invalid "rtorrent_rpc_url" provided: {url}')
 
   @staticmethod
   def __is_valid_deluge_url(url):

--- a/src/fertilizer/injection.py
+++ b/src/fertilizer/injection.py
@@ -4,6 +4,7 @@ import shutil
 from .clients.deluge import Deluge
 from .clients.qbittorrent import Qbittorrent
 from .clients.transmission import TransmissionBt
+from .clients.rtorrent import RTorrent
 from .config import Config
 from .errors import TorrentInjectionError
 from .parser import calculate_infohash, get_bencoded_data
@@ -40,7 +41,12 @@ class Injection:
     if not config.injection_link_directory:
       raise TorrentInjectionError("No injection link directory specified in the config file.")
 
-    if (not config.deluge_rpc_url) and (not config.transmission_rpc_url) and (not config.qbittorrent_url):
+    if (
+      (not config.deluge_rpc_url)
+      and (not config.transmission_rpc_url)
+      and (not config.qbittorrent_url)
+      and (not config.rtorrent_rpc_url)
+    ):
       raise TorrentInjectionError("No torrent client configuration specified in the config file.")
 
     return config
@@ -53,6 +59,8 @@ class Injection:
       return TransmissionBt(config.transmission_rpc_url)
     elif config.qbittorrent_url:
       return Qbittorrent(config.qbittorrent_url)
+    elif config.rtorrent_rpc_url:
+      return RTorrent(config.rtorrent_rpc_url)
 
   # If the torrent is a single bare file, this returns the path _to that file_
   # If the torrent is one or many files in a directory, this returns the topmost directory path

--- a/tests/clients/test_rtorrent.py
+++ b/tests/clients/test_rtorrent.py
@@ -1,0 +1,165 @@
+import xmlrpc.client
+
+import pytest
+import requests_mock
+
+from tests.helpers import SetupTeardown, get_torrent_path
+
+from fertilizer.parser import get_bencoded_data, calculate_infohash
+from fertilizer.filesystem import sane_join
+from fertilizer.errors import TorrentClientError, TorrentExistsInClientError
+from fertilizer.clients.rtorrent import RTorrent
+
+API_URL = "http://:secret@localhost:8080/RPC2"
+HREF = "http://localhost:8080/RPC2"
+
+
+def xmlrpc_response(value):
+  return xmlrpc.client.dumps((value,), methodresponse=True).encode("utf-8")
+
+
+def xmlrpc_fault(code, message):
+  return xmlrpc.client.dumps(xmlrpc.client.Fault(code, message)).encode("utf-8")
+
+
+def method_matcher(name):
+  return lambda request: f"<methodName>{name}</methodName>" in (request.text or "")
+
+
+def method_hash_matcher(name, infohash):
+  return lambda request: (
+    f"<methodName>{name}</methodName>" in (request.text or "") and infohash in (request.text or "")
+  )
+
+
+def _mock_torrent_info(
+  m, infohash, *, complete=1, directory="/tmp/data", base_path="/tmp/data/foo", name="foo", label="fertilizer"
+):
+  m.post(HREF, additional_matcher=method_hash_matcher("d.complete", infohash), content=xmlrpc_response(complete))
+  m.post(HREF, additional_matcher=method_hash_matcher("d.directory", infohash), content=xmlrpc_response(directory))
+  m.post(HREF, additional_matcher=method_hash_matcher("d.base_path", infohash), content=xmlrpc_response(base_path))
+  m.post(HREF, additional_matcher=method_hash_matcher("d.name", infohash), content=xmlrpc_response(name))
+  m.post(HREF, additional_matcher=method_hash_matcher("d.custom1", infohash), content=xmlrpc_response(label))
+
+
+@pytest.fixture
+def rtorrent_client():
+  return RTorrent(API_URL)
+
+
+class TestSetup(SetupTeardown):
+  def test_returns_version(self, rtorrent_client):
+    with requests_mock.Mocker() as m:
+      m.post(HREF, additional_matcher=method_matcher("system.client_version"), content=xmlrpc_response("0.9.8"))
+      assert rtorrent_client.setup() == "0.9.8"
+
+  def test_raises_on_http_error(self, rtorrent_client):
+    with requests_mock.Mocker() as m:
+      m.post(HREF, additional_matcher=method_matcher("system.client_version"), status_code=500)
+      with pytest.raises(TorrentClientError):
+        rtorrent_client.setup()
+
+
+class TestGetTorrentInfo(SetupTeardown):
+  def test_returns_torrent_details(self, rtorrent_client):
+    with requests_mock.Mocker() as m:
+      _mock_torrent_info(m, "ABC")
+      info = rtorrent_client.get_torrent_info("abc")
+
+      assert info["complete"] is True
+      assert info["label"] == "fertilizer"
+      assert info["save_path"] == "/tmp/data"
+      assert info["content_path"] == "/tmp/data/foo"
+
+  def test_uppercases_infohash(self, rtorrent_client):
+    with requests_mock.Mocker() as m:
+      _mock_torrent_info(m, "ABCDEF")
+      rtorrent_client.get_torrent_info("abcdef")
+
+      assert "ABCDEF" in m.request_history[0].text
+
+  def test_falls_back_to_joined_path_when_base_path_empty(self, rtorrent_client):
+    with requests_mock.Mocker() as m:
+      _mock_torrent_info(m, "ABC", base_path="")
+      info = rtorrent_client.get_torrent_info("abc")
+
+      assert info["content_path"] == sane_join("/tmp/data", "foo")
+
+  def test_raises_if_torrent_not_found(self, rtorrent_client):
+    with requests_mock.Mocker() as m:
+      m.post(
+        HREF,
+        additional_matcher=method_matcher("d.complete"),
+        content=xmlrpc_fault(-501, "Could not find info-hash."),
+      )
+      with pytest.raises(TorrentClientError) as excinfo:
+        rtorrent_client.get_torrent_info("abc")
+
+      assert "Torrent not found" in str(excinfo.value)
+
+
+class TestInjectTorrent(SetupTeardown):
+  def _new_hash(self, torrent_path):
+    return calculate_infohash(get_bencoded_data(torrent_path)).upper()
+
+  def test_injects_torrent(self, rtorrent_client):
+    torrent_path = get_torrent_path("red_source")
+    new_hash = self._new_hash(torrent_path)
+
+    with requests_mock.Mocker() as m:
+      # the new torrent does not exist yet -> its d.complete lookup faults
+      m.post(
+        HREF, additional_matcher=method_hash_matcher("d.complete", new_hash), content=xmlrpc_fault(-501, "not found")
+      )
+      # the source torrent is present and complete
+      _mock_torrent_info(m, "SOURCE")
+      m.post(HREF, additional_matcher=method_matcher("load.raw_start"), content=xmlrpc_response(0))
+
+      response = rtorrent_client.inject_torrent("source", torrent_path)
+
+      assert response == new_hash.lower()
+      load_body = m.request_history[-1].text
+      assert "load.raw_start" in load_body
+      assert "d.directory.set=/tmp/data" in load_body
+      assert "d.custom1.set=fertilizer" in load_body
+
+  def test_uses_save_path_override_if_present(self, rtorrent_client):
+    torrent_path = get_torrent_path("red_source")
+    new_hash = self._new_hash(torrent_path)
+
+    with requests_mock.Mocker() as m:
+      m.post(
+        HREF, additional_matcher=method_hash_matcher("d.complete", new_hash), content=xmlrpc_fault(-501, "not found")
+      )
+      _mock_torrent_info(m, "SOURCE")
+      m.post(HREF, additional_matcher=method_matcher("load.raw_start"), content=xmlrpc_response(0))
+
+      rtorrent_client.inject_torrent("source", torrent_path, save_path_override="/tmp/override")
+
+      assert "d.directory.set=/tmp/override" in m.request_history[-1].text
+
+  def test_raises_if_torrent_exists_in_client(self, rtorrent_client):
+    torrent_path = get_torrent_path("red_source")
+    new_hash = self._new_hash(torrent_path)
+
+    with requests_mock.Mocker() as m:
+      # the new torrent already exists -> its lookup succeeds
+      _mock_torrent_info(m, new_hash)
+
+      with pytest.raises(TorrentExistsInClientError):
+        rtorrent_client.inject_torrent("source", torrent_path)
+
+  def test_raises_if_source_torrent_not_complete(self, rtorrent_client):
+    torrent_path = get_torrent_path("red_source")
+    new_hash = self._new_hash(torrent_path)
+
+    with requests_mock.Mocker() as m:
+      m.post(
+        HREF, additional_matcher=method_hash_matcher("d.complete", new_hash), content=xmlrpc_fault(-501, "not found")
+      )
+      _mock_torrent_info(m, "SOURCE", complete=0)
+
+      with pytest.raises(TorrentClientError) as excinfo:
+        rtorrent_client.inject_torrent("source", torrent_path)
+
+      assert "not complete" in str(excinfo.value)


### PR DESCRIPTION
## What

Adds an **rTorrent** client so fertilizer can inject cross-seeded torrents directly into rTorrent, addressing #45.

## How

- New `clients/rtorrent.py` behind the existing `TorrentClient` seam. Like the other clients it speaks **HTTP XMLRPC over `requests`**, so it works with the RPC2 / flood / nginx-SCGIMount HTTP endpoints most rTorrent setups expose (the requester in #45 confirmed they front rTorrent with HTTP XMLRPC, not `scgi://`).
- `get_torrent_info` reads `d.complete` / `d.directory` / `d.base_path` / `d.name` / `d.custom1` (the ruTorrent-style label lives in `d.custom1`); infohashes are uppercased for rTorrent.
- `inject_torrent` loads via `load.raw_start` with `d.directory.set=<path>` and `d.custom1.set=<label>` run before the hash check, so the files fertilizer just linked are found and the torrent seeds. It guards against re-injecting an existing torrent and against injecting an incomplete source, matching the other clients.

## Config

New optional `RTORRENT_RPC_URL` env / `rtorrent_rpc_url` config key, e.g. `http://[user:pass@]host:8080/RPC2`. Wired into the config, the validator, and the injection client dispatch alongside Deluge / qBittorrent / Transmission.

## Tests

`tests/clients/test_rtorrent.py` covers setup, `get_torrent_info` (details, infohash uppercasing, base-path fallback, not-found fault) and `inject_torrent` (success, save-path override, already-exists, incomplete source), mocked with `requests_mock` like the Deluge/Transmission suites.

Closes #45.
